### PR TITLE
Show partially checked state for tristate checkboxes

### DIFF
--- a/lib/include/oclero/qlementine/utils/PrimitiveUtils.hpp
+++ b/lib/include/oclero/qlementine/utils/PrimitiveUtils.hpp
@@ -114,6 +114,9 @@ void drawComboBoxIndicator(const QRect& rect, QPainter* p);
 /// Draws the checkbox indicator (i.e. a check mark).
 void drawCheckBoxIndicator(const QRect& rect, QPainter* p, qreal progress = 1.);
 
+/// Draws the partially checked checkbox indicator (i.e. a dash).
+void drawPartiallyCheckedCheckBoxIndicator(const QRect& rect, QPainter* p, qreal progress = 1.);
+
 /// Draws the radiobutton indicator (i.e. a circle).
 void drawRadioButtonIndicator(const QRect& rect, QPainter* p, qreal progress = 1.);
 
@@ -204,7 +207,7 @@ void updateMessageBoxInformationIcon(QIcon& icon, QSize const& size, Theme const
 void drawRadioButton(QPainter* p, const QRect& rect, QColor const& bgColor, const QColor& borderColor, QColor const& fgColor, const qreal borderWidth, qreal progress);
 
 /// Draws a CheckButton indicator according to its checked state.
-void drawCheckButton(QPainter* p, const QRect& rect, qreal radius, const QColor& bgColor, const QColor& borderColor, const QColor& fgColor, const qreal borderWidth, qreal progress);
+void drawCheckButton(QPainter* p, const QRect& rect, qreal radius, const QColor& bgColor, const QColor& borderColor, const QColor& fgColor, const qreal borderWidth, qreal progress, CheckState checkState);
 
 /// Draws a menu separator.
 void drawMenuSeparator(QPainter* p, const QRect& rect, QColor const& color, const int thickness);

--- a/lib/src/style/Theme.cpp
+++ b/lib/src/style/Theme.cpp
@@ -406,8 +406,8 @@ QColor const& Theme::commandButtonIconColor(MouseState const mouse, ColorRole co
 QColor const& Theme::checkButtonBackgroundColor(MouseState const mouse, CheckState const checked) const {
   switch (checked) {
     case CheckState::Checked:
-      return buttonBackgroundColor(mouse, ColorRole::Primary);
     case CheckState::Indeterminate:
+      return buttonBackgroundColor(mouse, ColorRole::Primary);
     case CheckState::NotChecked:
     default:
       return buttonBackgroundColor(mouse, ColorRole::Neutral);

--- a/lib/src/utils/PrimitiveUtils.cpp
+++ b/lib/src/utils/PrimitiveUtils.cpp
@@ -462,6 +462,32 @@ void drawCheckBoxIndicator(const QRect& rect, QPainter* p, qreal progress) {
   p->drawPath(indicatorPath);
 }
 
+void drawPartiallyCheckedCheckBoxIndicator(const QRect& rect, QPainter* p, qreal progress) {
+  const auto w = rect.width();
+  const auto h = rect.width();
+  const auto x = rect.x();
+  const auto y = rect.y();
+  constexpr auto intendedSize = 16.;
+
+  const auto p1 = QPointF{ (4. / intendedSize) * w + x, (8. / intendedSize) * h + y };
+  const auto p2 = QPointF{ (12. / intendedSize) * w + x, (8. / intendedSize) * h + y };
+
+  QPainterPath indicatorPath;
+  indicatorPath.moveTo(p1);
+  indicatorPath.lineTo(p2);
+
+  // Draw only a certain percentage of the path.
+  if (1. - progress > 0.01) {
+    const auto lastPoint = indicatorPath.pointAtPercent(progress);
+    QPainterPath trimmedPath;
+    trimmedPath.moveTo(p1);
+    trimmedPath.lineTo(lastPoint);
+    indicatorPath = trimmedPath;
+  }
+
+  p->drawPath(indicatorPath);
+}
+
 void drawRadioButtonIndicator(const QRect& rect, QPainter* p, qreal progress) {
   constexpr auto intendedRatio = 8. / 16.;
 
@@ -742,7 +768,7 @@ void drawRadioButton(QPainter* p, const QRect& rect, QColor const& bgColor, cons
   }
 }
 
-void drawCheckButton(QPainter* p, const QRect& rect, qreal radius, const QColor& bgColor, const QColor& borderColor, QColor const& fgColor, const qreal borderWidth, qreal progress) {
+void drawCheckButton(QPainter* p, const QRect& rect, qreal radius, const QColor& bgColor, const QColor& borderColor, QColor const& fgColor, const qreal borderWidth, qreal progress, CheckState checkState) {
   // Background.
   p->setRenderHint(QPainter::RenderHint::Antialiasing);
   if (radius < 1) {
@@ -764,7 +790,11 @@ void drawCheckButton(QPainter* p, const QRect& rect, qreal radius, const QColor&
     p->setBrush(Qt::NoBrush);
     constexpr auto checkThickness = 2.;
     p->setPen(QPen{ fgColor, checkThickness, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin });
-    drawCheckBoxIndicator(rect, p, progress);
+    if (checkState == CheckState::Checked) {
+      drawCheckBoxIndicator(rect, p, progress);
+    } else if (checkState == CheckState::Indeterminate) {
+      drawPartiallyCheckedCheckBoxIndicator(rect, p, progress);
+    }
   }
 }
 

--- a/lib/src/utils/StateUtils.cpp
+++ b/lib/src/utils/StateUtils.cpp
@@ -124,7 +124,13 @@ FocusState getFocusState(QStyle::State const& state) {
 }
 
 CheckState getCheckState(QStyle::State const& state) {
-  return state.testFlag(QStyle::State_On) ? CheckState::Checked : CheckState::NotChecked;
+  if (state.testFlag(QStyle::State_On)) {
+    return CheckState::Checked;
+  } else if (state.testFlag(QStyle::State_NoChange)){
+    return CheckState::Indeterminate;
+  } else {
+    return CheckState::NotChecked;
+  }
 }
 
 CheckState getCheckState(bool checked) {


### PR DESCRIPTION
Fixes #2.

Showing it as a dash in this proposal, but other styles would be just fine too (a square, a dot...)

<img width="361" alt="image" src="https://github.com/oclero/qlementine/assets/36953703/36cd563c-fc83-4109-9763-ef3a29b1ce5d">
