### PR TITLE
Fix multiple compiling errors on win10x64+vs2022-amd64

### DIFF
--- a/lib/src/style/QlementineStyle.cpp
+++ b/lib/src/style/QlementineStyle.cpp
@@ -1,4 +1,4 @@
-// MIT License
+﻿// MIT License
 //
 // Copyright (c) 2023 Olivier Clero
 //
@@ -5891,13 +5891,13 @@ QColor const& QlementineStyle::groupBoxBorderColor(MouseState const mouse) const
   return mouse == MouseState::Disabled ? _impl->theme.borderColorDisabled : _impl->theme.borderColor;
 }
 
-QColor const& QlementineStyle::groupBoxBackgroundColor(MouseState const mouse) const {
-  return mouse == MouseState::Disabled ? _impl->theme.adaptativeColorTransparent : _impl->theme.adaptativeColor1;
-}
+// QColor const& QlementineStyle::groupBoxBackgroundColor(MouseState const mouse) const {
+//   return mouse == MouseState::Disabled ? _impl->theme.adaptativeColorTransparent : _impl->theme.adaptativeColor1;
+// }
 
-QColor const& QlementineStyle::groupBoxBorderColor(MouseState const mouse) const {
-  return mouse == MouseState::Disabled ? _impl->theme.borderColor2 : _impl->theme.borderColor3;
-}
+// QColor const& QlementineStyle::groupBoxBorderColor(MouseState const mouse) const {
+//   return mouse == MouseState::Disabled ? _impl->theme.borderColor2 : _impl->theme.borderColor3;
+// }
 
 QColor const& QlementineStyle::focusBorderColor() const {
   return _impl->theme.focusColor;

--- a/lib/src/tools/ThemeEditor.cpp
+++ b/lib/src/tools/ThemeEditor.cpp
@@ -1,4 +1,4 @@
-#include <oclero/qlementine/tools/ThemeEditor.hpp>
+﻿#include <oclero/qlementine/tools/ThemeEditor.hpp>
 
 #include <oclero/qlementine/widgets/ColorEditor.hpp>
 #include <oclero/qlementine/widgets/Label.hpp>

--- a/lib/src/utils/PrimitiveUtils.cpp
+++ b/lib/src/utils/PrimitiveUtils.cpp
@@ -1,4 +1,4 @@
-// MIT License
+﻿// MIT License
 //
 // Copyright (c) 2023 Olivier Clero
 //

--- a/lib/src/widgets/AbstractItemListWidget.cpp
+++ b/lib/src/widgets/AbstractItemListWidget.cpp
@@ -146,7 +146,7 @@ int AbstractItemListWidget::addItem(
   emit itemCountChanged();
   emit currentIndexChanged();
 
-  const auto [bgColor, fgColor, badgeBgColor, badgeFgColor] = getItemBgAndFgColor(_items.size(), MouseState::Normal);
+  const auto [bgColor, fgColor, badgeBgColor, badgeFgColor] = getItemBgAndFgColor((int)_items.size(), MouseState::Normal);
   bgColorAnimation->setDuration(animDuration);
   bgColorAnimation->setStartValue(QVariant::fromValue<QColor>(bgColor));
   bgColorAnimation->setEndValue(QVariant::fromValue<QColor>(bgColor));
@@ -167,7 +167,7 @@ int AbstractItemListWidget::addItem(
   badgeFgColorAnimation->setDuration(animDuration);
   badgeFgColorAnimation->setEasingCurve(QEasingCurve::Type::InOutCubic);
 
-  return _items.size() - 1;
+  return (int)_items.size() - 1;
 }
 
 void AbstractItemListWidget::removeItem(int index) {
@@ -431,7 +431,7 @@ QSize AbstractItemListWidget::sizeHint() const {
   }
   const auto itemCount = _items.size();
   const auto spacings = itemCount > 1 ? (itemCount - 1) * spacing : 0;
-  neededW += spacings + padding.left() + padding.right();
+  neededW += (int)spacings + padding.left() + padding.right();
   neededH += padding.top() + padding.bottom();
 
   return { neededW, neededH };

--- a/sandbox/src/SandboxWindow.cpp
+++ b/sandbox/src/SandboxWindow.cpp
@@ -1,4 +1,4 @@
-#include "SandboxWindow.hpp"
+﻿#include "SandboxWindow.hpp"
 
 #include <oclero/qlementine/style/QlementineStyle.hpp>
 #include <oclero/qlementine/utils/StateUtils.hpp>


### PR DESCRIPTION
1. Change ThemeEditor.cpp PrimitiveUtils.cpp SanboxWindow.cpp file encoding method to utf8-with-bom.
2. Remove duplicated QlementineStyle::groupBoxBackgroundColor/QlementineStyle::groupBoxBorderColor.
3. Explicitly convert size_t to int since vc++ treats C4267 as an error under warning_level_4.