### PR TITLE
With Qt6 `tabIndex` is a member of `QStyleOptionTab`

### DIFF
--- a/lib/src/utils/StyleUtils.cpp
+++ b/lib/src/utils/StyleUtils.cpp
@@ -94,16 +94,20 @@ bool shouldNotHaveWheelEvents(const QWidget* w) {
          || qobject_cast<const QAbstractSpinBox*>(w);
 }
 
-int getTabIndex(const QStyleOptionTab* optTab, const QWidget* parentWidget) {
-  if (const auto* optTabV4 = qstyleoption_cast<const QStyleOptionTabV4*>(optTab)) {
-    return optTabV4->tabIndex;
-  }
+int getTabIndex(const QStyleOptionTab* optTab, [[maybe_unused]]const QWidget* parentWidget) {
+  #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    return optTab->tabIndex;
+  #else
+    if (const auto* optTabV4 = qstyleoption_cast<const QStyleOptionTabV4*>(optTab)) {
+      return optTabV4->tabIndex;
+    }
 
-  if (const auto* tabBar = qobject_cast<const QTabBar*>(parentWidget)) {
-    return tabBar->tabAt(optTab->rect.topLeft());
-  }
+    if (const auto* tabBar = qobject_cast<const QTabBar*>(parentWidget)) {
+      return tabBar->tabAt(optTab->rect.topLeft());
+    }
 
-  return -1;
+    return -1;
+  #endif
 }
 
 int getTabCount(const QWidget* parentWidget) {


### PR DESCRIPTION
QStyleOptionTabV4 is no longer available with Qt6.