### PR TITLE
Build fixes for GCC 13 and MinGW compilers.

### DIFF
--- a/lib/src/csd/FramelessWindow.cpp
+++ b/lib/src/csd/FramelessWindow.cpp
@@ -40,7 +40,7 @@ struct FramelessWindow::Impl {
   QVBoxLayout* rootLayout{ nullptr };
   QMenuBar* menuBar{ nullptr };
   QWidget* contentWidget{ nullptr };
-#ifdef WIN32
+#ifdef _WIN32
   WindowsTitleBar* titleBar{ nullptr };
   QPointer<FramelessWindowBehavior> behavior{ nullptr };
 #endif
@@ -53,7 +53,7 @@ struct FramelessWindow::Impl {
     rootLayout->setSpacing(0);
     rootLayout->setContentsMargins(0, 0, 0, 0);
 
-#ifdef WIN32
+#ifdef _WIN32
     // Title bar: stuck the top.
     titleBar = new WindowsTitleBar(&owner);
     rootLayout->addWidget(titleBar, 0, Qt::AlignTop);
@@ -77,7 +77,7 @@ struct FramelessWindow::Impl {
     rootLayout->setMenuBar(menuBar);
 #endif
   }
-#ifdef WIN32
+#ifdef _WIN32
   void createBehavior() {
     if (behavior)
       return;
@@ -106,7 +106,7 @@ FramelessWindow::FramelessWindow(QWidget* parent)
   // Get rid of system's native window frame.
   setWindowFlag(Qt::WindowType::Window, true);
   setWindowFlag(Qt::WindowType::WindowContextHelpButtonHint, false);
-#ifdef WIN32
+#ifdef _WIN32
   setWindowFlag(Qt::FramelessWindowHint, true);
 #endif
   setFocusPolicy(Qt::NoFocus);
@@ -125,7 +125,7 @@ QWidget* FramelessWindow::contentWidget() const {
 
 void FramelessWindow::setContentWidget(QWidget* content) {
   if (content != _impl->contentWidget) {
-#ifdef WIN32
+#ifdef _WIN32
     const auto index = 1;
 #else
     const auto index = 0;
@@ -161,7 +161,7 @@ void FramelessWindow::paintEvent(QPaintEvent* e) {
 }
 
 bool FramelessWindow::event(QEvent* e) {
-#ifdef WIN32
+#ifdef _WIN32
   const auto type = e->type();
   switch (type) {
     case QEvent::Type::PaletteChange:

--- a/lib/src/csd/FramelessWindowBehavior.cpp
+++ b/lib/src/csd/FramelessWindowBehavior.cpp
@@ -28,12 +28,12 @@
 #include <QScreen>
 #include <QWindow>
 
-#ifdef WIN32
+#ifdef _WIN32
 #  include <QtWin>
 #  include <windows.h>
 #  include <windowsx.h>
 #  include <winuser.h>
-#endif // WIN32
+#endif // _WIN32
 
 #include <array>
 #include <algorithm>
@@ -127,7 +127,7 @@ void FramelessWindowBehavior::setSystemMenuAreaWidth(int width) {
 }
 
 void FramelessWindowBehavior::showSystemMenu(const QPoint& position) {
-#ifdef WIN32
+#ifdef _WIN32
   const auto hWnd = reinterpret_cast<HWND>(_parentWindowHandle->winId());
 
   const auto menu = ::GetSystemMenu(hWnd, FALSE);
@@ -142,7 +142,7 @@ void FramelessWindowBehavior::showSystemMenu(const QPoint& position) {
   }
 #else
   Q_UNUSED(position);
-#endif // WIN32
+#endif // _WIN32
 }
 
 bool FramelessWindowBehavior::eventFilter(QObject* obj, QEvent* evt) {
@@ -161,7 +161,7 @@ bool FramelessWindowBehavior::eventFilter(QObject* obj, QEvent* evt) {
 }
 
 bool FramelessWindowBehavior::nativeEventFilter(const QByteArray& eventType, void* message, long* result) {
-#ifdef WIN32
+#ifdef _WIN32
   if (eventType != QByteArrayLiteral("windows_generic_MSG"))
     return false;
 
@@ -369,7 +369,7 @@ void FramelessWindowBehavior::updateNativeWindowProperties() {
 }
 
 int FramelessWindowBehavior::hitTest(const QPoint& mousePos) const {
-#ifdef WIN32
+#ifdef _WIN32
   enum RegionMask {
     Client = 0x0000,
     Top = 0x0001,
@@ -431,13 +431,13 @@ int FramelessWindowBehavior::hitTest(const QPoint& mousePos) const {
   return hitTestNativeTitleBar(localPos) ? HTCAPTION : HTCLIENT;
 #else
   Q_UNUSED(mousePos);
-#endif // WIN32
+#endif // _WIN32
 
   return false;
 }
 
 bool FramelessWindowBehavior::hitTestNativeTitleBar(const QPoint& mousePos) const {
-#ifdef WIN32
+#ifdef _WIN32
   const int scaledTitleBarHeight = _titleBarHeight * _scaleFactor;
 
   if (!_parentWindowWidget)
@@ -478,12 +478,12 @@ bool FramelessWindowBehavior::hitTestNativeTitleBar(const QPoint& mousePos) cons
   }
 #else
   Q_UNUSED(mousePos);
-#endif // WIN32
+#endif // _WIN32
   return true;
 }
 
 QRect FramelessWindowBehavior::availableGeometry() const {
-#ifdef WIN32
+#ifdef _WIN32
   MONITORINFO monitorInfo{ 0, RECT(), RECT(), 0 };
   monitorInfo.cbSize = sizeof(MONITORINFO);
 
@@ -496,13 +496,13 @@ QRect FramelessWindowBehavior::availableGeometry() const {
 
   return QRect(monitorInfo.rcWork.left, monitorInfo.rcWork.top, monitorInfo.rcWork.right - monitorInfo.rcWork.left,
     monitorInfo.rcWork.bottom - monitorInfo.rcWork.top);
-#endif // WIN32
+#endif // _WIN32
 
   return QRect();
 }
 
 QRect FramelessWindowBehavior::systemMenuArea() const {
-#ifdef WIN32
+#ifdef _WIN32
   QRect rect{ 0, 0, _systemMenuAreaWidth, _titleBarHeight };
 
   if (isMaximized(_parentWindowHandle)) {
@@ -512,13 +512,13 @@ QRect FramelessWindowBehavior::systemMenuArea() const {
   }
 
   return rect;
-#endif // WIN32
+#endif // _WIN32
 
   return QRect();
 }
 
 void FramelessWindowBehavior::updateNativeWindowProperties(QWindow* const window) {
-#ifdef WIN32
+#ifdef _WIN32
   if (!window)
     return;
 
@@ -561,11 +561,11 @@ void FramelessWindowBehavior::updateNativeWindowProperties(QWindow* const window
   }
 #else
   Q_UNUSED(window);
-#endif // WIN32
+#endif // _WIN32
 }
 
 bool FramelessWindowBehavior::isMaximized(const QWindow* const window) {
-#ifdef WIN32
+#ifdef _WIN32
   if (!window)
     return false;
 
@@ -581,6 +581,6 @@ bool FramelessWindowBehavior::isMaximized(const QWindow* const window) {
 #else
   Q_UNUSED(window);
   return false;
-#endif // WIN32
+#endif // _WIN32
 }
 } // namespace oclero::qlementine

--- a/lib/src/resources/ResourceInitialization.cpp
+++ b/lib/src/resources/ResourceInitialization.cpp
@@ -29,7 +29,7 @@ void qlementineResourceInitialization() {
   // Loads the QRC content.
   Q_INIT_RESOURCE(qlementine);
   Q_INIT_RESOURCE(qlementine_font_roboto);
-#if defined(WIN32)
+#if defined(_WIN32)
   Q_INIT_RESOURCE(qlementine_font_inter_windows);
 #else
   Q_INIT_RESOURCE(qlementine_font_inter);

--- a/lib/src/style/QlementineStyle.cpp
+++ b/lib/src/style/QlementineStyle.cpp
@@ -96,7 +96,7 @@ struct QlementineStyleImpl {
 
   /// Registers all the theme fonts to Qt's font database.
   void installFonts() {
-#if defined(WIN32)
+#if defined(_WIN32)
     const auto regularFontPath = QString(":/qlementine/resources/fonts/inter/%1.ttf");
 #else
     const auto regularFontPath = QString(":/qlementine/resources/fonts/inter/%1.otf");
@@ -722,11 +722,11 @@ void QlementineStyle::drawPrimitive(PrimitiveElement pe, const QStyleOption* opt
       const auto& borderColor = toolTipBorderColor();
       // More investigation is needed to make rounded tooltips on Windows.
       // Currently we only support this feature on MacOS.
-#ifdef WIN32
+#ifdef _WIN32
       constexpr auto radius = 0;
 #else
       const auto radius = _impl->theme.borderRadius;
-#endif // WIN32
+#endif // _WIN32
 
       const auto borderW = _impl->theme.borderWidth;
       p->setRenderHint(QPainter::Antialiasing, true);
@@ -4752,7 +4752,7 @@ void QlementineStyle::polish(QWidget* w) {
 
 // Currently we only support tooltips with rounded corners on MacOS.
 // More investigation is need to make it work on Windows.
-#ifndef WIN32
+#ifndef _WIN32
   if (w->inherits("QTipLabel")) {
     // TODO: turn this into addAlphaChannel
     w->setBackgroundRole(QPalette::NoRole);

--- a/lib/src/widgets/Switch.cpp
+++ b/lib/src/widgets/Switch.cpp
@@ -248,9 +248,10 @@ void Switch::setupAnimation() {
 const QColor& Switch::getBgColor() const {
   const auto* style = this->style();
   const auto* qlementineStyle = qobject_cast<const QlementineStyle*>(style);
+  const auto palette = style->standardPalette();
   const auto& bgColor = qlementineStyle ? qlementineStyle->switchGrooveColor(
                           getMouseState(isDown(), _isMouseOver, isEnabled()), getCheckState(isChecked()))
-                                        : style->standardPalette().color(
+                                        : palette.color(
                                           isEnabled() ? QPalette::ColorGroup::Normal : QPalette::ColorGroup::Disabled,
                                           QPalette::ColorRole::Button);
   return bgColor;
@@ -259,11 +260,12 @@ const QColor& Switch::getBgColor() const {
 const QColor& Switch::getBorderColor() const {
   const auto* style = this->style();
   const auto* qlementineStyle = qobject_cast<const QlementineStyle*>(style);
+  const auto palette = style->standardPalette();
   const auto& borderColor =
     qlementineStyle
       ? qlementineStyle->switchGrooveBorderColor(
         getMouseState(isDown(), _isMouseOver, isEnabled()), getFocusState(hasFocus()), getCheckState(isChecked()))
-      : style->standardPalette().color(
+      : palette.color(
         isEnabled() ? QPalette::ColorGroup::Normal : QPalette::ColorGroup::Disabled, QPalette::ColorRole::ButtonText);
   return borderColor;
 }
@@ -271,9 +273,10 @@ const QColor& Switch::getBorderColor() const {
 const QColor& Switch::getFgColor() const {
   const auto* style = this->style();
   const auto* qlementineStyle = qobject_cast<const QlementineStyle*>(style);
+  const auto palette = style->standardPalette();
   const auto& fgColor = qlementineStyle ? qlementineStyle->switchHandleColor(
                           getMouseState(isDown(), _isMouseOver, isEnabled()), getCheckState(isChecked()))
-                                        : style->standardPalette().color(
+                                        : palette.color(
                                           isEnabled() ? QPalette::ColorGroup::Normal : QPalette::ColorGroup::Disabled,
                                           QPalette::ColorRole::ButtonText);
   return fgColor;
@@ -282,10 +285,11 @@ const QColor& Switch::getFgColor() const {
 const QColor& Switch::getTextColor() const {
   const auto* style = this->style();
   const auto* qlementineStyle = qobject_cast<const QlementineStyle*>(style);
+  const auto palette = style->standardPalette();
   const auto& textColor =
     qlementineStyle
       ? qlementineStyle->labelForegroundColor(getMouseState(isDown(), _isMouseOver, isEnabled()), this)
-      : style->standardPalette().color(
+      : palette.color(
         isEnabled() ? QPalette::ColorGroup::Normal : QPalette::ColorGroup::Disabled, QPalette::ColorRole::Text);
   return textColor;
 }


### PR DESCRIPTION
This PR fixes two build issues I found while preparing new updated Solarus build images that support Qlementine.

1. Fix dangling reference warnings in GCC 13
2. Use correct preprocessor macro for Windows code paths

Each of these is fixed on an individual commit for an easier review, but explanations are also provided below.

In GCC 13, a new [dangling references warning](https://trofi.github.io/posts/264-gcc-s-new-Wdangling-reference-warning.html) was introduced. Qlementine has code that is (falsely) triggering this warning and failing to build due to `-Werror`. This PR fixes the warnings-turned-errors by using intermediate assignments instead.

<details>
<summary>The first commit in this PR fixes these false positive dangling reference warnings.</summary>

```
/qlementine/lib/src/widgets/Switch.cpp: In member function ‘const QColor& oclero::qlementine::Switch::getBgColor() const’:
/qlementine/lib/src/widgets/Switch.cpp:251:15: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
  251 |   const auto& bgColor = qlementineStyle ? qlementineStyle->switchGrooveColor(
      |               ^~~~~~~
/qlementine/lib/src/widgets/Switch.cpp:253:73: note: the temporary was destroyed at the end of the full expression ‘QStyle::standardPalette().QPalette::color((((const oclero::qlementine::Switch*)this)->oclero::qlementine::Switch::<anonymous>.QAbstractButton::<anonymous>.QWidget::isEnabled() ? QPalette::Normal :  QPalette::Disabled), QPalette::Button)’
  253 |                                         : style->standardPalette().color(
      |                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  254 |                                           isEnabled() ? QPalette::ColorGroup::Normal : QPalette::ColorGroup::Disabled,
      |                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  255 |                                           QPalette::ColorRole::Button);
      |                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/qlementine/lib/src/widgets/Switch.cpp: In member function ‘const QColor& oclero::qlementine::Switch::getBorderColor() const’:
/qlementine/lib/src/widgets/Switch.cpp:262:15: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
  262 |   const auto& borderColor =
      |               ^~~~~~~~~~~
/qlementine/lib/src/widgets/Switch.cpp:266:39: note: the temporary was destroyed at the end of the full expression ‘QStyle::standardPalette().QPalette::color((((const oclero::qlementine::Switch*)this)->oclero::qlementine::Switch::<anonymous>.QAbstractButton::<anonymous>.QWidget::isEnabled() ? QPalette::Normal :  QPalette::Disabled), QPalette::ButtonText)’
  266 |       : style->standardPalette().color(
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  267 |         isEnabled() ? QPalette::ColorGroup::Normal : QPalette::ColorGroup::Disabled, QPalette::ColorRole::ButtonText);
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/qlementine/lib/src/widgets/Switch.cpp: In member function ‘const QColor& oclero::qlementine::Switch::getFgColor() const’:
/qlementine/lib/src/widgets/Switch.cpp:274:15: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
  274 |   const auto& fgColor = qlementineStyle ? qlementineStyle->switchHandleColor(
      |               ^~~~~~~
/qlementine/lib/src/widgets/Switch.cpp:276:73: note: the temporary was destroyed at the end of the full expression ‘QStyle::standardPalette().QPalette::color((((const oclero::qlementine::Switch*)this)->oclero::qlementine::Switch::<anonymous>.QAbstractButton::<anonymous>.QWidget::isEnabled() ? QPalette::Normal :  QPalette::Disabled), QPalette::ButtonText)’
  276 |                                         : style->standardPalette().color(
      |                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  277 |                                           isEnabled() ? QPalette::ColorGroup::Normal : QPalette::ColorGroup::Disabled,
      |                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  278 |                                           QPalette::ColorRole::ButtonText);
      |                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/qlementine/lib/src/widgets/Switch.cpp: In member function ‘const QColor& oclero::qlementine::Switch::getTextColor() const’:
/qlementine/lib/src/widgets/Switch.cpp:285:15: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
  285 |   const auto& textColor =
      |               ^~~~~~~~~
/qlementine/lib/src/widgets/Switch.cpp:288:39: note: the temporary was destroyed at the end of the full expression ‘QStyle::standardPalette().QPalette::color((((const oclero::qlementine::Switch*)this)->oclero::qlementine::Switch::<anonymous>.QAbstractButton::<anonymous>.QWidget::isEnabled() ? QPalette::Normal :  QPalette::Disabled), QPalette::Text)’
  288 |       : style->standardPalette().color(
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  289 |         isEnabled() ? QPalette::ColorGroup::Normal : QPalette::ColorGroup::Disabled, QPalette::ColorRole::Text);
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
</details>

The second build error is due to (incorrectly) using a `WIN32` user macro instead of the [standard](https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros) predefined `_WIN32` compiler macro. When compiling with MSVC, it automatically adds the _user_ defined macro `WIN32` for backwards compatibility, but this is not the case for other compilers such as MinGW. Therefore, when compiling with MinGW, the wrong code paths are chosen causing a missing symbol in the built library that then causes a linking error in client applications.

<details>
<summary>The second commit replaces `WIN32` with `_WIN32` and fixes this linking error in client applications.</summary>

```
[ 98%] Linking CXX executable sandbox.exe
/usr/lib/gcc/x86_64-w64-mingw32/13.1.0/../../../../x86_64-w64-mingw32/bin/ld: ../lib/libqlementine.a(ResourceInitialization.cpp.obj):ResourceInitialization.cpp:(.text+0x18): undefined reference to `qInitResources_qlementine_font_inter()'
/usr/lib/gcc/x86_64-w64-mingw32/13.1.0/../../../../x86_64-w64-mingw32/bin/ld: ../lib/libqlementine.a(ResourceInitialization.cpp.obj):ResourceInitialization.cpp:(.text+0x38): undefined reference to `qInitResources_qlementine_font_inter()'
collect2: error: ld returned 1 exit status
make[2]: *** [sandbox/CMakeFiles/sandbox.dir/build.make:185: sandbox/sandbox.exe] Error 1
make[1]: *** [CMakeFiles/Makefile2:203: sandbox/CMakeFiles/sandbox.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```
</details>