### PR TITLE
Fix windows build in case of empty CMAKE_PREFIX_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,9 @@ set(PROJECT_NAMESPACE "oclero")
 # With Qt5, it was "path/to/Qt/6.7.0/msvc2019_64/lib/cmake/Qt6",
 # but with Qt6, it is now "path/to/Qt/6.7.0/msvc2019_64".
 if(WIN32)
-  string(FIND ${CMAKE_PREFIX_PATH} "/lib/cmake/Qt6" USING_Qt6_INDEX)
+  string(FIND "${CMAKE_PREFIX_PATH}" "/lib/cmake/Qt6" USING_Qt6_INDEX)
   if(NOT ${USING_Qt6_INDEX} EQUAL -1)
-    string(REPLACE "/lib/cmake/Qt6" "" ${CMAKE_PREFIX_PATH} ${CMAKE_PREFIX_PATH})
+    string(REPLACE "/lib/cmake/Qt6" "" "${CMAKE_PREFIX_PATH}" "${CMAKE_PREFIX_PATH}")
   endif()
 endif()
 


### PR DESCRIPTION
Fix build failure if `CMAKE_PREFIX_PATH` is empty:
```
-- Found Solarus: /builds/solarus-games/solarus-quest-editor/staging/include (found suitable exact version "2.0.0")
-- Found SolarusGui: /builds/solarus-games/solarus-quest-editor/staging/include
CMake Error at build/_deps/qlementine-src/CMakeLists.txt:22 (string):
  string sub-command FIND requires 3 or 4 parameters.


-- Configuring incomplete, errors occurred!
Cleaning up project directory and file based variables
ERROR: Job failed: exit code 1
```