### PR TITLE
Make sure to clear focus of any widgets contained by an Expander

### DIFF
--- a/lib/include/oclero/qlementine/utils/WidgetUtils.hpp
+++ b/lib/include/oclero/qlementine/utils/WidgetUtils.hpp
@@ -17,6 +17,8 @@ qreal getDpi(const QWidget* widget);
 
 QWindow* getWindow(const QWidget* widget);
 
+void clearFocus(QWidget* widget, bool recursive);
+
 template<class T>
 T* findFirstParentOfType(QWidget* child) {
   auto* parent = child;

--- a/lib/include/oclero/qlementine/widgets/Expander.hpp
+++ b/lib/include/oclero/qlementine/widgets/Expander.hpp
@@ -52,6 +52,5 @@ private:
   Qt::Orientation _orientation{ Qt::Orientation::Vertical };
   QVariantAnimation _animation;
   QPointer<QWidget> _content{ nullptr };
-  QHash<QWidget*, Qt::FocusPolicy> _focusPolicies;
 };
 } // namespace oclero::qlementine

--- a/lib/include/oclero/qlementine/widgets/Expander.hpp
+++ b/lib/include/oclero/qlementine/widgets/Expander.hpp
@@ -52,5 +52,6 @@ private:
   Qt::Orientation _orientation{ Qt::Orientation::Vertical };
   QVariantAnimation _animation;
   QPointer<QWidget> _content{ nullptr };
+  QHash<QWidget*, Qt::FocusPolicy> _focusPolicies;
 };
 } // namespace oclero::qlementine

--- a/lib/src/utils/WidgetUtils.cpp
+++ b/lib/src/utils/WidgetUtils.cpp
@@ -78,4 +78,17 @@ QWindow* getWindow(const QWidget* widget) {
   }
   return nullptr;
 }
+
+void clearFocus(QWidget* widget, bool recursive) {
+  if (widget) {
+    widget->clearFocus();
+
+    if (recursive) {
+      const auto children = widget->findChildren<QWidget*>();
+      for (auto* child : children) {
+        clearFocus(child, recursive);
+      }
+    }
+  }
+}
 } // namespace oclero::qlementine

--- a/lib/src/widgets/Expander.cpp
+++ b/lib/src/widgets/Expander.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include <oclero/qlementine/widgets/Expander.hpp>
+#include <oclero/qlementine/utils/WidgetUtils.hpp>
 
 #include <QStyle>
 #include <QEvent>
@@ -106,6 +107,7 @@ void Expander::setExpanded(bool expanded) {
     if (_expanded) {
       emit aboutToExpand();
     } else {
+      oclero::qlementine::clearFocus(this, true);
       emit aboutToShrink();
     }
 

--- a/lib/src/widgets/Expander.cpp
+++ b/lib/src/widgets/Expander.cpp
@@ -109,6 +109,20 @@ void Expander::setExpanded(bool expanded) {
       emit aboutToShrink();
     }
 
+    for (auto* widget : findChildren<QWidget*>()) {
+      if (!_expanded) {
+        _focusPolicies.insert(widget, widget->focusPolicy());
+        widget->setFocusPolicy(Qt::NoFocus);
+        widget->clearFocus();
+      } else if (_focusPolicies.contains(widget)) {
+        widget->setFocusPolicy(_focusPolicies[widget]);
+      }
+    }
+
+    if (_expanded) {
+      _focusPolicies.clear();
+    }
+
     const auto isVertical = _orientation == Qt::Orientation::Vertical;
     const auto current = isVertical ? height() : width();
     const auto contentSizeHint = _content->sizeHint();
@@ -155,6 +169,7 @@ void Expander::setContent(QWidget* content) {
   if (content != _content) {
     if (_content) {
       _content->removeEventFilter(this);
+      _focusPolicies.clear();
       delete _content;
     }
 
@@ -169,6 +184,14 @@ void Expander::setContent(QWidget* content) {
       _content->setParent(this);
       _content->installEventFilter(this);
       _content->setVisible(_expanded);
+
+      if (!_expanded) {
+        for (auto* widget : findChildren<QWidget*>()) {
+          _focusPolicies.insert(widget, widget->focusPolicy());
+          widget->setFocusPolicy(Qt::NoFocus);
+          widget->clearFocus();
+        }
+      }
     }
     updateGeometry();
     emit contentChanged();

--- a/lib/src/widgets/Expander.cpp
+++ b/lib/src/widgets/Expander.cpp
@@ -109,20 +109,6 @@ void Expander::setExpanded(bool expanded) {
       emit aboutToShrink();
     }
 
-    for (auto* widget : findChildren<QWidget*>()) {
-      if (!_expanded) {
-        _focusPolicies.insert(widget, widget->focusPolicy());
-        widget->setFocusPolicy(Qt::NoFocus);
-        widget->clearFocus();
-      } else if (_focusPolicies.contains(widget)) {
-        widget->setFocusPolicy(_focusPolicies[widget]);
-      }
-    }
-
-    if (_expanded) {
-      _focusPolicies.clear();
-    }
-
     const auto isVertical = _orientation == Qt::Orientation::Vertical;
     const auto current = isVertical ? height() : width();
     const auto contentSizeHint = _content->sizeHint();
@@ -169,7 +155,6 @@ void Expander::setContent(QWidget* content) {
   if (content != _content) {
     if (_content) {
       _content->removeEventFilter(this);
-      _focusPolicies.clear();
       delete _content;
     }
 
@@ -184,14 +169,6 @@ void Expander::setContent(QWidget* content) {
       _content->setParent(this);
       _content->installEventFilter(this);
       _content->setVisible(_expanded);
-
-      if (!_expanded) {
-        for (auto* widget : findChildren<QWidget*>()) {
-          _focusPolicies.insert(widget, widget->focusPolicy());
-          widget->setFocusPolicy(Qt::NoFocus);
-          widget->clearFocus();
-        }
-      }
     }
     updateGeometry();
     emit contentChanged();


### PR DESCRIPTION
When an Expander contains widget that can be focused, a visual glitch appears when hiding the contents of the Expander. This PR fixes the issue by clearing the focus of any children widgets when the contents are invisible. See the following screenshot for how the visual glitch looks like: 
![image](https://github.com/user-attachments/assets/30108e4b-d56f-4b41-89fe-34033da6b5be)
