### PR TITLE
Use `Q_EMIT`, `Q_SIGNALS`, `Q_SLOTS` instead of `emit`, `signals`, `slots`

### DIFF
--- a/lib/include/oclero/qlementine/tools/ThemeEditor.hpp
+++ b/lib/include/oclero/qlementine/tools/ThemeEditor.hpp
@@ -20,7 +20,7 @@ public:
   const Theme& theme() const;
   void setTheme(const Theme& theme);
 
-signals:
+Q_SIGNALS:
   void themeChanged(const oclero::qlementine::Theme& theme);
 
 private:

--- a/lib/include/oclero/qlementine/widgets/ColorButton.hpp
+++ b/lib/include/oclero/qlementine/widgets/ColorButton.hpp
@@ -28,7 +28,7 @@ public:
 
   QSize sizeHint() const override;
 
-signals:
+Q_SIGNALS:
   void colorChanged();
   void colorModeChanged();
 

--- a/lib/include/oclero/qlementine/widgets/ColorEditor.hpp
+++ b/lib/include/oclero/qlementine/widgets/ColorEditor.hpp
@@ -28,7 +28,7 @@ public:
   ColorMode colorMode() const;
   void setColorMode(ColorMode mode);
 
-signals:
+Q_SIGNALS:
   void colorChanged();
   void colorModeChanged();
 

--- a/lib/include/oclero/qlementine/widgets/Popover.hpp
+++ b/lib/include/oclero/qlementine/widgets/Popover.hpp
@@ -79,7 +79,7 @@ public:
   void setHorizontalSpacing(int spacing);
   Q_SIGNAL void horizontalSpacingChanged();
 
-public slots:
+public Q_SLOTS
   void openPopover();
   void closePopover();
 

--- a/lib/include/oclero/qlementine/widgets/Popover.hpp
+++ b/lib/include/oclero/qlementine/widgets/Popover.hpp
@@ -79,7 +79,7 @@ public:
   void setHorizontalSpacing(int spacing);
   Q_SIGNAL void horizontalSpacingChanged();
 
-public Q_SLOTS
+public Q_SLOTS:
   void openPopover();
   void closePopover();
 

--- a/lib/include/oclero/qlementine/widgets/Popover.hpp
+++ b/lib/include/oclero/qlementine/widgets/Popover.hpp
@@ -83,7 +83,7 @@ public slots:
   void openPopover();
   void closePopover();
 
-signals:
+Q_SIGNALS:
   void aboutToOpen();
   void aboutToClose();
   void opened();

--- a/lib/include/oclero/qlementine/widgets/PopoverButton.hpp
+++ b/lib/include/oclero/qlementine/widgets/PopoverButton.hpp
@@ -27,7 +27,7 @@ public:
 public slots:
   void setPopoverOpened(bool opened);
 
-signals:
+Q_SIGNALS:
   void popoverOpenedChanged(bool opened);
 
 protected:

--- a/lib/include/oclero/qlementine/widgets/PopoverButton.hpp
+++ b/lib/include/oclero/qlementine/widgets/PopoverButton.hpp
@@ -24,7 +24,7 @@ public:
 
   Popover* popover() const;
 
-public slots:
+public Q_SLOTS
   void setPopoverOpened(bool opened);
 
 Q_SIGNALS:

--- a/lib/include/oclero/qlementine/widgets/PopoverButton.hpp
+++ b/lib/include/oclero/qlementine/widgets/PopoverButton.hpp
@@ -24,7 +24,7 @@ public:
 
   Popover* popover() const;
 
-public Q_SLOTS
+public Q_SLOTS:
   void setPopoverOpened(bool opened);
 
 Q_SIGNALS:

--- a/lib/src/style/EventFilters.cpp
+++ b/lib/src/style/EventFilters.cpp
@@ -233,7 +233,7 @@ bool TabBarEventFilter::eventFilter(QObject* watchedObject, QEvent* evt) {
       const auto tabIndex = _tabBar->tabAt(mouseEvent->pos());
       if (tabIndex != -1 && _tabBar->isTabVisible(tabIndex)) {
         evt->accept();
-        emit _tabBar->tabCloseRequested(tabIndex);
+        Q_EMIT _tabBar->tabCloseRequested(tabIndex);
         return true;
       }
     } else if (mouseEvent->button() == Qt::MouseButton::RightButton) {
@@ -241,7 +241,7 @@ bool TabBarEventFilter::eventFilter(QObject* watchedObject, QEvent* evt) {
       const auto tabIndex = _tabBar->tabAt(mouseEvent->pos());
       if (tabIndex != -1 && _tabBar->isTabVisible(tabIndex)) {
         evt->accept();
-        emit _tabBar->customContextMenuRequested(mouseEvent->pos());
+        Q_EMIT _tabBar->customContextMenuRequested(mouseEvent->pos());
         return true;
       }
     }

--- a/lib/src/style/QlementineStyle.cpp
+++ b/lib/src/style/QlementineStyle.cpp
@@ -266,7 +266,7 @@ Theme const& QlementineStyle::theme() const {
 void QlementineStyle::setTheme(Theme const& theme) {
   if (_impl->theme != theme) {
     _impl->theme = theme;
-    emit themeChanged();
+    Q_EMIT themeChanged();
 
     triggerCompleteRepaint();
   }
@@ -286,7 +286,7 @@ bool QlementineStyle::animationsEnabled() const {
 void QlementineStyle::setAnimationsEnabled(bool enabled) {
   if (enabled != _impl->animations.enabled()) {
     _impl->animations.setEnabled(enabled);
-    emit animationsEnabledChanged();
+    Q_EMIT animationsEnabledChanged();
     triggerCompleteRepaint();
   }
 }

--- a/lib/src/style/ThemeManager.cpp
+++ b/lib/src/style/ThemeManager.cpp
@@ -25,8 +25,8 @@ void ThemeManager::setStyle(QlementineStyle* style) {
   if (style != _style) {
     _style = style;
     synchronizeThemeOnStyle();
-    emit currentThemeChanged();
-    emit themeCountChanged();
+    Q_EMIT currentThemeChanged();
+    Q_EMIT themeCountChanged();
   }
 }
 
@@ -36,7 +36,7 @@ const std::vector<Theme>& ThemeManager::themes() const {
 
 void ThemeManager::addTheme(const Theme& theme) {
   _themes.emplace_back(theme);
-  emit themeCountChanged();
+  Q_EMIT themeCountChanged();
   if (_currentIndex < 0) {
     setCurrentThemeIndex(0);
   }
@@ -82,7 +82,7 @@ void ThemeManager::setCurrentThemeIndex(int index) {
     if (index != _currentIndex) {
       _currentIndex = index;
       synchronizeThemeOnStyle();
-      emit currentThemeChanged();
+      Q_EMIT currentThemeChanged();
     }
   }
 }

--- a/lib/src/tools/ThemeEditor.cpp
+++ b/lib/src/tools/ThemeEditor.cpp
@@ -30,7 +30,7 @@
   { \
     const auto pair = makeColorEditorAndLabel(#NAME, DESCRIPTION, &owner, theme.NAME, [this](const QColor& c) { \
       theme.NAME = c; \
-      emit owner.themeChanged(theme); \
+      Q_EMIT owner.themeChanged(theme); \
     }); \
     this->NAME##Editor = pair.second; \
     formLayout->addRow(pair.first, pair.second); \
@@ -40,7 +40,7 @@
   { \
     const auto pair = makeTextEditorAndLabel(#NAME, DESCRIPTION, &owner, [this](const QString& s) { \
       theme.meta.NAME = s; \
-      emit owner.themeChanged(theme); \
+      Q_EMIT owner.themeChanged(theme); \
     }); \
     this->NAME##Editor = pair.second; \
     formLayout->addRow(pair.first, pair.second); \
@@ -516,7 +516,7 @@ void ThemeEditor::setTheme(const Theme& theme) {
   if (theme != _impl->theme) {
     _impl->theme = theme;
     _impl->updateUi();
-    emit themeChanged(_impl->theme);
+    Q_EMIT themeChanged(_impl->theme);
   }
 }
 } // namespace oclero::qlementine

--- a/lib/src/widgets/AbstractItemListWidget.cpp
+++ b/lib/src/widgets/AbstractItemListWidget.cpp
@@ -55,7 +55,7 @@ void AbstractItemListWidget::setCurrentIndex(int index) {
     update();
     updateCurrentIndexAnimation();
     updateItemsAnimations();
-    emit currentIndexChanged();
+    Q_EMIT currentIndexChanged();
   }
 }
 
@@ -124,8 +124,8 @@ int AbstractItemListWidget::addItem(
   updateGeometry();
   updateItemsAnimations();
   updateCurrentIndexAnimation();
-  emit itemCountChanged();
-  emit currentIndexChanged();
+  Q_EMIT itemCountChanged();
+  Q_EMIT currentIndexChanged();
 
   const auto [bgColor, fgColor, badgeBgColor, badgeFgColor] = getItemBgAndFgColor(itemCount(), MouseState::Normal);
   bgColorAnimation->setDuration(animDuration);
@@ -168,7 +168,7 @@ void AbstractItemListWidget::removeItem(int index) {
       setCurrentIndex(std::max(-1, index - 1));
     }
 
-    emit itemCountChanged();
+    Q_EMIT itemCountChanged();
   }
 }
 
@@ -272,7 +272,7 @@ void AbstractItemListWidget::setIconSize(const QSize& size) {
     _iconSize = size;
     updateGeometry();
     update();
-    emit iconSizeChanged();
+    Q_EMIT iconSizeChanged();
   }
 }
 
@@ -288,7 +288,7 @@ void AbstractItemListWidget::setItemsShouldExpand(bool expand) {
     updateCurrentIndexAnimation(true);
     _focusFrame->update();
     _focusFrame->updateGeometry();
-    emit itemsShouldExpandChanged();
+    Q_EMIT itemsShouldExpandChanged();
   }
 }
 

--- a/lib/src/widgets/Action.cpp
+++ b/lib/src/widgets/Action.cpp
@@ -115,8 +115,8 @@ bool Action::shortcutEditable() const {
 void Action::setShortcutEditable(bool editable) {
   if (editable != _shortcutEditable) {
     _shortcutEditable = editable;
-    emit shortcutEditableChanged();
-    emit changed();
+    Q_EMIT shortcutEditableChanged();
+    Q_EMIT changed();
   }
 }
 
@@ -130,7 +130,7 @@ void Action::setUserShortcut(const QKeySequence& shortcut) {
       //  Save the default shortcut.
       _defaultShortcut = this->shortcut();
       _shortcutEditedByUser = true;
-      emit shortcutEditedByUserChanged();
+      Q_EMIT shortcutEditedByUserChanged();
     }
 
     _userShortcut = shortcut;
@@ -138,7 +138,7 @@ void Action::setUserShortcut(const QKeySequence& shortcut) {
     // Set the new shortcut on the action.
     setShortcut(_userShortcut);
 
-    emit userShortcutChanged();
+    Q_EMIT userShortcutChanged();
   }
 }
 
@@ -147,8 +147,8 @@ void Action::resetShortcut() {
     _userShortcut = {};
     _shortcutEditedByUser = false;
 
-    emit userShortcutChanged();
-    emit shortcutEditedByUserChanged();
+    Q_EMIT userShortcutChanged();
+    Q_EMIT shortcutEditedByUserChanged();
     setShortcut(_defaultShortcut);
   }
 }
@@ -164,8 +164,8 @@ const QString& Action::description() const {
 void Action::setDescription(const QString& description) {
   if (description != _description) {
     _description = description;
-    emit descriptionChanged();
-    emit changed();
+    Q_EMIT descriptionChanged();
+    Q_EMIT changed();
   }
 }
 } // namespace oclero::qlementine

--- a/lib/src/widgets/ColorButton.cpp
+++ b/lib/src/widgets/ColorButton.cpp
@@ -61,7 +61,7 @@ void ColorButton::setColor(const QColor& color) {
   if (newColor != _color) {
     _color = newColor;
     update();
-    emit colorChanged();
+    Q_EMIT colorChanged();
   }
 }
 
@@ -72,7 +72,7 @@ ColorMode ColorButton::colorMode() const {
 void ColorButton::setColorMode(ColorMode mode) {
   if (mode != _colorMode) {
     _colorMode = mode;
-    emit colorModeChanged();
+    Q_EMIT colorModeChanged();
     setColor(adaptColorToMode(_color));
   }
 }

--- a/lib/src/widgets/ColorEditor.cpp
+++ b/lib/src/widgets/ColorEditor.cpp
@@ -44,12 +44,12 @@ void ColorEditor::setup(const QColor& initialColor) {
   // Connect widgets together.
   QObject::connect(_colorButton, &ColorButton::colorChanged, this, [this]() {
     syncLineEditFromButton();
-    emit colorChanged();
+    Q_EMIT colorChanged();
   });
 
   QObject::connect(_colorButton, &ColorButton::colorModeChanged, this, [this]() {
     syncLineEditFromButton();
-    emit colorModeChanged();
+    Q_EMIT colorModeChanged();
   });
 
 

--- a/lib/src/widgets/Expander.cpp
+++ b/lib/src/widgets/Expander.cpp
@@ -31,9 +31,9 @@ Expander::Expander(QWidget* parent)
 
   QObject::connect(&_animation, &QVariantAnimation::finished, this, [this]() {
     if (_expanded) {
-      emit didExpand();
+      Q_EMIT didExpand();
     } else {
-      emit didShrink();
+      Q_EMIT didShrink();
     }
   });
 }
@@ -104,9 +104,9 @@ void Expander::setExpanded(bool expanded) {
     _expanded = expanded;
 
     if (_expanded) {
-      emit aboutToExpand();
+      Q_EMIT aboutToExpand();
     } else {
-      emit aboutToShrink();
+      Q_EMIT aboutToShrink();
     }
 
     const auto isVertical = _orientation == Qt::Orientation::Vertical;
@@ -120,7 +120,7 @@ void Expander::setExpanded(bool expanded) {
     _animation.setEndValue(QVariant::fromValue<int>(target));
     _animation.start();
 
-    emit expandedChanged();
+    Q_EMIT expandedChanged();
   }
 }
 
@@ -143,7 +143,7 @@ void Expander::setOrientation(Qt::Orientation orientation) {
     }
 
     updateGeometry();
-    emit orientationChanged();
+    Q_EMIT orientationChanged();
   }
 }
 
@@ -171,7 +171,7 @@ void Expander::setContent(QWidget* content) {
       _content->setVisible(_expanded);
     }
     updateGeometry();
-    emit contentChanged();
+    Q_EMIT contentChanged();
   }
 }
 } // namespace oclero::qlementine

--- a/lib/src/widgets/IconWidget.cpp
+++ b/lib/src/widgets/IconWidget.cpp
@@ -52,7 +52,7 @@ const QSize& IconWidget::iconSize() const {
 void IconWidget::setIconSize(const QSize& iconSize) {
   if (iconSize != _iconSize) {
     _iconSize = iconSize;
-    emit iconSizeChanged();
+    Q_EMIT iconSizeChanged();
     updateGeometry();
     update();
   }

--- a/lib/src/widgets/Label.cpp
+++ b/lib/src/widgets/Label.cpp
@@ -38,7 +38,7 @@ void Label::setRole(TextRole role) {
     _role = role;
     // Change text font, size and color.
     updatePaletteFromTheme();
-    emit roleChanged();
+    Q_EMIT roleChanged();
   }
 }
 

--- a/lib/src/widgets/LineEdit.cpp
+++ b/lib/src/widgets/LineEdit.cpp
@@ -113,7 +113,7 @@ void LineEdit::setStatus(Status status) {
   if (status != _status) {
     _status = status;
     update();
-    emit statusChanged();
+    Q_EMIT statusChanged();
   }
 }
 } // namespace oclero::qlementine

--- a/lib/src/widgets/PlainTextEdit.cpp
+++ b/lib/src/widgets/PlainTextEdit.cpp
@@ -41,7 +41,7 @@ void PlainTextEdit::setStatus(Status status) {
   if (status != _status) {
     _status = status;
     update();
-    emit statusChanged();
+    Q_EMIT statusChanged();
   }
 }
 

--- a/lib/src/widgets/Popover.cpp
+++ b/lib/src/widgets/Popover.cpp
@@ -106,10 +106,10 @@ Popover::Popover(QWidget* parent)
   });
   QObject::connect(&_opacityAnimation, &QVariantAnimation::finished, this, [this]() {
     if (_opened) {
-      emit opened();
+      Q_EMIT opened();
     } else {
       _mousePressWasOnAnchor = false;
-      emit closed();
+      Q_EMIT closed();
       hide();
     }
   });
@@ -125,7 +125,7 @@ void Popover::setPreferredPosition(Position position) {
     if (isVisible()) {
       updatePopoverGeometry();
     }
-    emit preferredPositionChanged();
+    Q_EMIT preferredPositionChanged();
   }
 }
 
@@ -140,7 +140,7 @@ void Popover::setPreferredAlignment(Alignment alignment) {
     if (isVisible()) {
       updatePopoverGeometry();
     }
-    emit preferredAlignmentChanged();
+    Q_EMIT preferredAlignmentChanged();
   }
 }
 
@@ -171,7 +171,7 @@ void Popover::setContentWidget(QWidget* widget) {
     if (isVisible()) {
       updatePopoverGeometry();
     }
-    emit contentWidgetChanged();
+    Q_EMIT contentWidgetChanged();
   }
 }
 
@@ -183,16 +183,16 @@ void Popover::setOpened(bool opened) {
   if (opened != _opened) {
     _opened = opened;
     if (_opened) {
-      emit aboutToOpen();
+      Q_EMIT aboutToOpen();
       updatePopoverGeometry();
       show();
       startAnimation();
     } else {
-      emit aboutToClose();
+      Q_EMIT aboutToClose();
       startAnimation();
     }
 
-    emit openedChanged();
+    Q_EMIT openedChanged();
   }
 }
 
@@ -203,7 +203,7 @@ QMargins Popover::padding() const {
 void Popover::setPadding(const QMargins& padding) {
   if (padding != _frameLayout->contentsMargins()) {
     _frameLayout->setContentsMargins(padding);
-    emit paddingChanged();
+    Q_EMIT paddingChanged();
   }
 }
 
@@ -244,7 +244,7 @@ void Popover::setAnchorWidget(QWidget* widget) {
     if (isVisible()) {
       updatePopoverGeometry();
     }
-    emit anchorWidgetChanged();
+    Q_EMIT anchorWidgetChanged();
   }
 }
 
@@ -258,7 +258,7 @@ void Popover::setVerticalSpacing(int spacing) {
     if (isVisible()) {
       updatePopoverGeometry();
     }
-    emit verticalSpacingChanged();
+    Q_EMIT verticalSpacingChanged();
   }
 }
 
@@ -272,7 +272,7 @@ void Popover::setHorizontalSpacing(int spacing) {
     if (isVisible()) {
       updatePopoverGeometry();
     }
-    emit horizontalSpacingChanged();
+    Q_EMIT horizontalSpacingChanged();
   }
 }
 

--- a/lib/src/widgets/PopoverButton.cpp
+++ b/lib/src/widgets/PopoverButton.cpp
@@ -24,10 +24,10 @@ PopoverButton::PopoverButton(const QString& text, const QIcon& icon, QWidget* pa
   });
   QObject::connect(_popover, &Popover::openedChanged, this, [this]() {
     update();
-    emit popoverOpenedChanged(_popover->isOpened());
+    Q_EMIT popoverOpenedChanged(_popover->isOpened());
   });
   QObject::connect(_popover, &Popover::contentWidgetChanged, this, [this]() {
-    emit popoverContentWidgetChanged();
+    Q_EMIT popoverContentWidgetChanged();
   });
 }
 

--- a/lib/src/widgets/RoundedFocusFrame.cpp
+++ b/lib/src/widgets/RoundedFocusFrame.cpp
@@ -11,7 +11,7 @@ const RadiusesF& RoundedFocusFrame::radiuses() const {
 void RoundedFocusFrame::setRadiuses(const RadiusesF& radiuses) {
   if (radiuses != _radiuses) {
     _radiuses = radiuses;
-    emit radiusesChanged();
+    Q_EMIT radiusesChanged();
     update();
   }
 }

--- a/lib/src/widgets/StatusBadgeWidget.cpp
+++ b/lib/src/widgets/StatusBadgeWidget.cpp
@@ -27,7 +27,7 @@ void StatusBadgeWidget::setBadge(StatusBadge badge) {
   if (badge != _badge) {
     _badge = badge;
     update();
-    emit badgeChanged();
+    Q_EMIT badgeChanged();
   }
 }
 
@@ -40,7 +40,7 @@ void StatusBadgeWidget::setBadgeSize(StatusBadgeSize size) {
     _badgeSize = size;
     updateGeometry();
     update();
-    emit badgeSizeChanged();
+    Q_EMIT badgeSizeChanged();
   }
 }
 


### PR DESCRIPTION
This PR allows this library to be compatible with projects that have `QT_NO_KEYWORDS` defined. This means that `emit`, `signals`, and `slots` keywords cannot be used in these projects and their respective macros, `Q_EMIT`, `Q_SIGNALS`, `Q_SLOTS`, must be used instead.

This good thing about using the macros instead of the keywords is that whether `QT_NO_KEYWORDS` is set or not, this library will still work with all projects.

