### PR TITLE
Different border positions for QToolBar

### DIFF
--- a/lib/src/style/QlementineStyle.cpp
+++ b/lib/src/style/QlementineStyle.cpp
@@ -32,6 +32,7 @@
 #include <QPixmapCache>
 #include <QApplication>
 #include <QMenuBar>
+#include <QToolBar>
 #include <QTableView>
 #include <QCheckBox>
 #include <QRadioButton>
@@ -563,18 +564,50 @@ void QlementineStyle::drawPrimitive(PrimitiveElement pe, const QStyleOption* opt
         const auto& rect = optToolBar->rect;
         p->fillRect(rect, bgColor);
 
-        // TODO Handle ToolBar when it's on left/right side, bottom + middle.
         const auto lineW = _impl->theme.borderWidth;
-        const auto x1 = rect.x();
-        const auto y1 = rect.y() + rect.height() - lineW / 2.;
-        const auto x2 = rect.x() + rect.width();
-        const auto y2 = y1;
-        const auto p1 = QPointF(x1, y1);
-        const auto p2 = QPointF(x2, y2);
         const auto& lineColor = toolBarBorderColor();
         p->setPen(QPen(lineColor, lineW, Qt::SolidLine, Qt::FlatCap));
         p->setBrush(Qt::NoBrush);
-        p->drawLine(p1, p2);
+
+        auto* toolBar = qobject_cast<const QToolBar*>(w);
+        const auto orientation = toolBar->orientation();
+        const auto allowedAreas = toolBar->allowedAreas();
+
+        if (orientation == Qt::Horizontal) {
+          if (allowedAreas.testFlag(Qt::TopToolBarArea)) {
+            // Draw bottom border
+            const auto x1 = rect.x();
+            const auto y1 = rect.y() + rect.height() - lineW / 2.;
+            const auto x2 = rect.x() + rect.width();
+            const auto y2 = y1;
+            p->drawLine(QPointF(x1, y1), QPointF(x2, y2));
+          }
+          if (allowedAreas.testFlag(Qt::BottomToolBarArea)) {
+            // Draw top border
+            const auto x1 = rect.x();
+            const auto y1 = rect.y() + lineW / 2.;
+            const auto x2 = rect.x() + rect.width();
+            const auto y2 = y1;
+            p->drawLine(QPointF(x1, y1), QPointF(x2, y2));
+          }
+        } else if (orientation == Qt::Vertical) {
+          if (allowedAreas.testFlag(Qt::LeftToolBarArea)) {
+            // Draw right border
+            const auto x1 = rect.x() + rect.width() - lineW / 2.;
+            const auto y1 = rect.y();
+            const auto x2 = x1;
+            const auto y2 = rect.y() + rect.height();
+            p->drawLine(QPointF(x1, y1), QPointF(x2, y2));
+          }
+          if (allowedAreas.testFlag(Qt::RightToolBarArea)) {
+            // Draw left border
+            const auto x1 = rect.x() + lineW / 2.;
+            const auto y1 = rect.y();
+            const auto x2 = x1;
+            const auto y2 = rect.y() + rect.height();
+            p->drawLine(QPointF(x1, y1), QPointF(x2, y2));
+          }
+        }
       }
       return;
     case PE_PanelLineEdit:

--- a/sandbox/src/SandboxWindow.cpp
+++ b/sandbox/src/SandboxWindow.cpp
@@ -259,6 +259,88 @@ struct SandboxWindow::Impl {
     owner.setCentralWidget(globalScrollArea);
   }
 
+  void setupUI_toolBar() {
+    auto addToolBarIcon = [](QToolBar* toolbar, int btnNum = 1) {
+      const auto icon = getTestQIcon();
+      for (int i = 0; i < btnNum; i++) {
+        auto* toolButton = new QToolButton(toolbar);
+        toolButton->setIcon(icon);
+        toolButton->setToolButtonStyle(Qt::ToolButtonIconOnly);
+        toolbar->addWidget(toolButton);
+      }
+    };
+
+    auto* contentWidget = new CustomBgWidget(windowContent);
+    windowContentLayout->addWidget(contentWidget);
+
+    contentWidget->showBounds = true;
+    contentWidget->bgColor = Qt::white;
+
+    contentWidget->setMinimumSize(500, 400);
+    auto* contentLayout = new QHBoxLayout(contentWidget);
+    contentLayout->setContentsMargins(1, 1, 1, 1);
+    contentLayout->setSpacing(0);
+
+    {
+      auto* leftToolBar = new QToolBar(contentWidget);
+      contentLayout->addWidget(leftToolBar);
+      leftToolBar->setOrientation(Qt::Orientation::Vertical);
+      leftToolBar->setAllowedAreas(Qt::ToolBarArea::LeftToolBarArea);
+      addToolBarIcon(leftToolBar, 3);
+    }
+
+    {
+      auto* centralWidget = new QWidget(contentWidget);
+      contentLayout->addWidget(centralWidget);
+      auto* layout = new QVBoxLayout(centralWidget);
+      layout->setContentsMargins(0, 0, 0, 0);
+      layout->setSpacing(0);
+
+      {
+        auto* topToolBar = new QToolBar(centralWidget);
+        layout->addWidget(topToolBar);
+        topToolBar->setOrientation(Qt::Orientation::Horizontal);
+        topToolBar->setAllowedAreas(Qt::ToolBarArea::TopToolBarArea);
+        addToolBarIcon(topToolBar, 4);
+      }
+      {
+        auto* widget = new CustomBgWidget(centralWidget);
+        layout->addWidget(widget);
+        widget->showBounds = false;
+        widget->bgColor = Qt::white;
+      }
+      {
+        auto* middleToolbar = new QToolBar(centralWidget);
+        layout->addWidget(middleToolbar);
+        middleToolbar->setOrientation(Qt::Orientation::Horizontal);
+        middleToolbar->setAllowedAreas(Qt::ToolBarArea::TopToolBarArea | Qt::ToolBarArea::BottomToolBarArea);
+        addToolBarIcon(middleToolbar, 3);
+      }
+      {
+        auto* widget = new CustomBgWidget(centralWidget);
+        layout->addWidget(widget);
+        widget->showBounds = false;
+        widget->bgColor = Qt::white;
+        widget->setStyleSheet("background-color: white");
+      }
+      {
+        auto* bottomToolBar = new QToolBar(centralWidget);
+        layout->addWidget(bottomToolBar);
+        bottomToolBar->setOrientation(Qt::Orientation::Horizontal);
+        bottomToolBar->setAllowedAreas(Qt::ToolBarArea::BottomToolBarArea);
+        addToolBarIcon(bottomToolBar, 2);
+      }
+    }
+
+    {
+      auto* rightToolBar = new QToolBar(contentWidget);
+      contentLayout->addWidget(rightToolBar);
+      rightToolBar->setOrientation(Qt::Orientation::Vertical);
+      rightToolBar->setAllowedAreas(Qt::ToolBarArea::RightToolBarArea);
+      addToolBarIcon(rightToolBar, 3);
+    }
+  }
+
   void setupShortcuts() {
     auto* enableShortcut = new QShortcut(Qt::CTRL | Qt::Key_E, &owner);
     enableShortcut->setAutoRepeat(false);
@@ -1774,6 +1856,7 @@ SandboxWindow::SandboxWindow(ThemeManager* themeManager, QWidget* parent)
     // _impl->setupUI_blur();
     // _impl->setupUI_themeEditor();
     // _impl->setupUI_messageBox();
+    _impl->setupUI_toolBar();
   }
   _impl->endSetupUI();
   oclero::qlementine::centerWidget(this);

--- a/sandbox/src/SandboxWindow.cpp
+++ b/sandbox/src/SandboxWindow.cpp
@@ -1856,7 +1856,7 @@ SandboxWindow::SandboxWindow(ThemeManager* themeManager, QWidget* parent)
     // _impl->setupUI_blur();
     // _impl->setupUI_themeEditor();
     // _impl->setupUI_messageBox();
-    _impl->setupUI_toolBar();
+    // _impl->setupUI_toolBar();
   }
   _impl->endSetupUI();
   oclero::qlementine::centerWidget(this);


### PR DESCRIPTION
Problem: Currently, border drawing is supported only for the upper panel. Therefore, visual bugs are possible when the panel is on the left and the border is drawn from below, and the area above the status bar becomes thicker.

![image](https://github.com/user-attachments/assets/6c136b48-fd8b-4b1e-a2fb-cd76454ef33d)

For this reason, different border positions for Toolbar widget were added.

Depending on orientation and allowed areas properties of the toolbar, the borders will be drawn at different positions.

For the horizontal toolbar, the bottom border is drawn if the TopToolBarArea flag is set in the allowedAreas property, the top border is drawn if the BottomToolBarArea flag is set. If both flags are set, both borders will be drawn. If both flags are not set, the borders will not be drawn.

For the vertical panel, the behavior is similar. The right border is drawn if the LeftToolBarAreaflag is set. The left border is drawn if the RightToolBarArea is set. 

Before the changes:

![image](https://github.com/user-attachments/assets/886f0c89-5818-4262-b493-27a52ee98e55)

After the changes:

![image](https://github.com/user-attachments/assets/e0d7a7fb-29dc-43e9-9a33-ae35a33bba7b)
