### PR TITLE
Fix loss popover binding on multi screen

### DIFF
--- a/lib/src/widgets/Popover.cpp
+++ b/lib/src/widgets/Popover.cpp
@@ -661,7 +661,10 @@ void Popover::updatePopoverGeometry() {
   } else {
     // Check if the preferred position fits entirely on screen, or try another position until it works.
     const auto& priority = positionPriority(_preferredPosition);
-    const auto screenGeometry = screen()->availableGeometry();
+    const auto screenGeometry = 
+      _anchorWidget 
+        ? _anchorWidget->screen()->availableGeometry()
+        : screen()->availableGeometry();
     for (const auto position : priority) {
       auto geometry = getGeometryForPosition(position, _preferredAlignment);
 
@@ -711,7 +714,10 @@ const std::array<Popover::Position, 4>& Popover::positionPriority(Position const
 QRect Popover::getGeometryForPosition(Position const position, Alignment const alignment) const {
   // Take the content size as a basis, rather than the whole size that includes drop shadow.
   const auto popoverSize = _frame->sizeHint();
-  const auto screenGeometry = screen()->availableGeometry().marginsRemoved(_screenPadding);
+  const auto screenGeometry =
+    _anchorWidget 
+      ? _anchorWidget->screen()->availableGeometry().marginsRemoved(_screenPadding)
+      : screen()->availableGeometry().marginsRemoved(_screenPadding);
   const auto popoverFittedSize = QSize{
     std::min(screenGeometry.width(), popoverSize.width()),
     std::min(screenGeometry.height(), popoverSize.height()),


### PR DESCRIPTION
Problem: When using multiple screens, the popup window is always attached to only one. If the anchor widget moves to another screen, the popup window will remain on the first screen.

<img width="1065" height="702" alt="Снимок экрана 2025-07-29 153001 - 2" src="https://github.com/user-attachments/assets/a14e3b02-73df-4451-9b65-4197fade24b8" />

<img width="918" height="730" alt="Снимок экрана 2025-07-29 153043" src="https://github.com/user-attachments/assets/3a17cb6e-56ff-4c0a-9d62-f6cb034026b2" />
