### PR TITLE
Drawing the caret should be non-antialiased

### DIFF
--- a/lib/src/style/QlementineStyle.cpp
+++ b/lib/src/style/QlementineStyle.cpp
@@ -656,6 +656,8 @@ void QlementineStyle::drawPrimitive(PrimitiveElement pe, const QStyleOption* opt
         if (!isPlainLineEdit) {
           drawRoundedRectBorder(p, rect, currentBorderColor, borderW, radiuses);
         }
+        // Drawing the caret should be non-antialiased
+        p->setRenderHint(QPainter::Antialiasing, false);
       }
       return;
     case PE_IndicatorArrowDown:


### PR DESCRIPTION
The default cursor rendering of LineEdit is non-antialiased. qlementine's stylized rendering code will make it antialiased, which may cause the caret width jumps from 1px to 2px.

Before the fix:
<img width="67" height="35" alt="0" src="https://github.com/user-attachments/assets/cd7aa669-ee11-47c7-9cd0-97a12a8e629d" />
After the fix:
<img width="65" height="37" alt="1" src="https://github.com/user-attachments/assets/01cd4989-250c-4ab4-9034-4c6b4a9a5b18" />
