### PR TITLE
Update LineEditButtonEventFilter.hpp

### DIFF
--- a/lib/src/style/eventFilters/LineEditButtonEventFilter.hpp
+++ b/lib/src/style/eventFilters/LineEditButtonEventFilter.hpp
@@ -41,7 +41,7 @@ protected:
         // Prevent moving from qlineedit_p.cpp:540
         evt->ignore();
         // Instead, place the button by ourselves.
-        auto moveEvent = reinterpret_cast<QMoveEvent*>(evt);
+        auto moveEvent = static_cast<QMoveEvent*>(evt);
         const int proposedX = moveEvent->pos().x();
         const auto* parentLineEdit = _button->parentWidget();
         const auto parentRect = parentLineEdit->rect();
@@ -62,9 +62,8 @@ protected:
         }
 
         const bool isRTL = parentLineEdit->layoutDirection() == Qt::RightToLeft;
-        bool alignLeft = (isLeading && !isRTL) || (!isLeading && isRTL);
-       
-        if (alignLeft) {
+              
+        if (isLeading && !isRTL) || (!isLeading && isRTL) {
           buttonX = parentRect.x() + spacing;
         } else {
           buttonX = parentRect.x() + parentRect.width() - buttonW - spacing;

--- a/lib/src/style/eventFilters/LineEditButtonEventFilter.hpp
+++ b/lib/src/style/eventFilters/LineEditButtonEventFilter.hpp
@@ -53,14 +53,10 @@ protected:
         int buttonX = 0;
 
         bool isLeading = false;
-        if (const auto* toolButton = qobject_cast<QToolButton*>(_button)) {
-          if (const auto* action = toolButton->defaultAction()) {
-            if (proposedX < (parentRect.width() / 2)) {
+        if (proposedX < (parentRect.width() / 2)) {
               isLeading = true;
             }
-          }
-        }
-
+       
         const bool isRTL = parentLineEdit->layoutDirection() == Qt::RightToLeft;
               
         if (isLeading && !isRTL) || (!isLeading && isRTL) {

--- a/lib/src/style/eventFilters/LineEditButtonEventFilter.hpp
+++ b/lib/src/style/eventFilters/LineEditButtonEventFilter.hpp
@@ -12,6 +12,7 @@
 #include <QPointer>
 #include <QLineEdit>
 #include <QPainter>
+#include <QMoveEvent>
 
 namespace oclero::qlementine {
 class LineEditButtonEventFilter : public QObject {
@@ -40,14 +41,34 @@ protected:
         // Prevent moving from qlineedit_p.cpp:540
         evt->ignore();
         // Instead, place the button by ourselves.
+        auto moveEvent = reinterpret_cast<QMoveEvent*>(evt);
+        const int proposedX = moveEvent->pos().x();
         const auto* parentLineEdit = _button->parentWidget();
         const auto parentRect = parentLineEdit->rect();
         const auto& theme = _style ? _style->theme() : Theme{};
         const auto buttonH = theme.controlHeightMedium;
         const auto buttonW = buttonH;
         const auto spacing = theme.spacing / 2;
-        const auto buttonX = parentRect.x() + parentRect.width() - buttonW - spacing;
         const auto buttonY = parentRect.y() + (parentRect.height() - buttonH) / 2;
+        int buttonX = 0;
+
+        bool isLeading = false;
+        if (const auto* toolButton = qobject_cast<QToolButton*>(_button)) {
+          if (const auto* action = toolButton->defaultAction()) {
+            if (proposedX < (parentRect.width() / 2)) {
+              isLeading = true;
+            }
+          }
+        }
+
+        const bool isRTL = parentLineEdit->layoutDirection() == Qt::RightToLeft;
+        bool alignLeft = (isLeading && !isRTL) || (!isLeading && isRTL);
+       
+        if (alignLeft) {
+          buttonX = parentRect.x() + spacing;
+        } else {
+          buttonX = parentRect.x() + parentRect.width() - buttonW - spacing;
+        }
         _button->setGeometry(buttonX, buttonY, buttonW, buttonH);
         return true;
       } break;

--- a/lib/src/style/eventFilters/LineEditButtonEventFilter.hpp
+++ b/lib/src/style/eventFilters/LineEditButtonEventFilter.hpp
@@ -42,7 +42,7 @@ protected:
         evt->ignore();
         // Instead, place the button by ourselves.
         auto moveEvent = static_cast<QMoveEvent*>(evt);
-        const int proposedX = moveEvent->pos().x();
+        const auto proposedX = moveEvent->pos().x();
         const auto* parentLineEdit = _button->parentWidget();
         const auto parentRect = parentLineEdit->rect();
         const auto& theme = _style ? _style->theme() : Theme{};
@@ -50,15 +50,15 @@ protected:
         const auto buttonW = buttonH;
         const auto spacing = theme.spacing / 2;
         const auto buttonY = parentRect.y() + (parentRect.height() - buttonH) / 2;
-        int buttonX = 0;
+        auto buttonX = 0;
 
-        bool isLeading = false;
+        auto isLeading = false;
         if (proposedX < (parentRect.width() / 2)) {
-              isLeading = true;
-            }
-       
-        const bool isRTL = parentLineEdit->layoutDirection() == Qt::RightToLeft;
-              
+          isLeading = true;
+        }
+
+        const auto isRTL = parentLineEdit->layoutDirection() == Qt::RightToLeft;
+
         if ((isLeading && !isRTL) || (!isLeading && isRTL)) {
           buttonX = parentRect.x() + spacing;
         } else {

--- a/lib/src/style/eventFilters/LineEditButtonEventFilter.hpp
+++ b/lib/src/style/eventFilters/LineEditButtonEventFilter.hpp
@@ -59,7 +59,7 @@ protected:
        
         const bool isRTL = parentLineEdit->layoutDirection() == Qt::RightToLeft;
               
-        if (isLeading && !isRTL) || (!isLeading && isRTL) {
+        if ((isLeading && !isRTL) || (!isLeading && isRTL)) {
           buttonX = parentRect.x() + spacing;
         } else {
           buttonX = parentRect.x() + parentRect.width() - buttonW - spacing;

--- a/lib/src/style/eventFilters/LineEditButtonEventFilter.hpp
+++ b/lib/src/style/eventFilters/LineEditButtonEventFilter.hpp
@@ -41,7 +41,7 @@ protected:
         // Prevent moving from qlineedit_p.cpp:540
         evt->ignore();
         // Instead, place the button by ourselves.
-        auto moveEvent = static_cast<QMoveEvent*>(evt);
+        const auto* moveEvent = static_cast<QMoveEvent*>(evt);
         const auto proposedX = moveEvent->pos().x();
         const auto* parentLineEdit = _button->parentWidget();
         const auto parentRect = parentLineEdit->rect();


### PR DESCRIPTION
Add the handling of QLineEdit::LeadingPosition and RTL for QActions for QLineEdit. Fixes the position of the Icon in a lineedit that was added with QLineEdit::LeadingPosition.