### PR TITLE
Don't exceed the screen height when expanding a tree view

### DIFF
--- a/lib/src/style/eventFilters/ComboboxItemViewFilter.hpp
+++ b/lib/src/style/eventFilters/ComboboxItemViewFilter.hpp
@@ -102,8 +102,9 @@ private:
           // Height.
           const auto absoluteMinHeight = qlementineStyle->theme().controlHeightLarge * (isTreeView ? 5 : 1);
           const auto screen = view->screen();
+          const auto viewGlobalY = view->mapToGlobal(QPoint(0, 0)).y();  // Don't exceed the screen height when expanding a tree view.
           const auto absoluteMaxHeight = screen != nullptr ?
-                                             screen->geometry().height() - 128 :
+                                             screen->geometry().height() - 128 - viewGlobalY :
                                              qlementineStyle->theme().controlHeightLarge * 10;
           const auto height = std::min(absoluteMaxHeight, std::max(absoluteMinHeight, viewMinimumSizeHint().height()));
 


### PR DESCRIPTION
Expanding a big tree view inside a combobox was increasing the size of the tree view too much, sometimes exceeding the screen height and even possibly without scrollers.

Root cause: we were computing the maximum height as if the top of the tree view was always on the top of the screen, but this is not always the case, e.g. when you expand some nodes of the tree view.

Fix: just take into account the y position of the top of the tree view when computing the maximum height.