### PR TITLE
fixes some double free (to be checked) and stack overflow

### DIFF
--- a/lib/include/oclero/qlementine/style/ThemeManager.hpp
+++ b/lib/include/oclero/qlementine/style/ThemeManager.hpp
@@ -51,7 +51,7 @@ private:
 
 private:
   std::vector<Theme> _themes;
-  QPointer<QlementineStyle> _style{ nullptr };
+  QlementineStyle* _style{ nullptr };
   int _currentIndex{ -1 };
 };
 } // namespace oclero::qlementine

--- a/lib/src/style/eventFilters/ComboboxItemViewFilter.hpp
+++ b/lib/src/style/eventFilters/ComboboxItemViewFilter.hpp
@@ -44,13 +44,17 @@ protected:
     switch (evt->type()) {
       case QEvent::Type::ChildAdded: {
         if (watchedObject == _comboBox) {
-          const auto* childEvent = static_cast<QChildEvent*>(evt);
-          const auto* child = childEvent->child();
-          if (child == _comboBox->view()) {
-            if (auto* qlementine = qobject_cast<QlementineStyle*>(_comboBox->style())) {
-              _comboBox->setItemDelegate(new ComboBoxDelegate(_comboBox, *qlementine));
+          if (!_childAddedCurrentlyProcessing) {
+            _childAddedCurrentlyProcessing = true;
+            const auto* childEvent = static_cast<QChildEvent*>(evt);
+            const auto* child = childEvent->child();
+            if (child == _comboBox->view()) {
+              if (auto* qlementine = qobject_cast<QlementineStyle*>(_comboBox->style())) {
+                _comboBox->setItemDelegate(new ComboBoxDelegate(_comboBox, *qlementine));
+              }
             }
           }
+         _childAddedCurrentlyProcessing = false;
         }
       } break;
       case QEvent::Type::Show:
@@ -144,6 +148,8 @@ private:
   QAbstractItemView* _view{ nullptr };
   int _initialMaxHeight{ 0 };
   QModelIndex _clickedIndex{};
+
+  bool _childAddedCurrentlyProcessing{ false };
 };
 
 class ComboboxFilter : public QObject {

--- a/lib/src/style/eventFilters/TabBarEventFilter.hpp
+++ b/lib/src/style/eventFilters/TabBarEventFilter.hpp
@@ -133,7 +133,7 @@ public:
 
 private:
   QTabBar* _tabBar{ nullptr };
-  QPointer<QToolButton> _leftButton{ nullptr };
-  QPointer<QToolButton> _rightButton{ nullptr };
+  QToolButton* _leftButton{ nullptr };
+  QToolButton* _rightButton{ nullptr };
 };
 } // namespace oclero::qlementine


### PR DESCRIPTION
This PR fixes two double free detected due to QPointer usage, leading to a crash on my system. 
While Qt documentation mentions QPointer as a weak pointer, implementation clearly shows the stored object might be deleted in the case it has no reference anymore. 

The other commit (e27a48d5485779a245924e7570ccd3295a9eaf96) fixes a recursive call of ComboboxItemViewFilter::eventFilter() that leads to a stack overflow in my use-case.