### PR TITLE
Enable building as a shared library

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,6 +13,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        library_type: [static, shared]
+        include:
+          - library_type: static
+            preset: linux
+            description: "Static Library"
+          - library_type: shared
+            preset: linux-shared
+            description: "Shared Library"
+
+    name: Build (${{ matrix.description }})
 
     steps:
       - name: Check Out
@@ -26,10 +38,7 @@ jobs:
           target: desktop
           arch: linux_gcc_64
 
-      - name: Build the library.
+      - name: Build the library (${{ matrix.description }})
         run: |
-          cmake --preset linux -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install
-          cmake --build --preset linux --target install
-
-      - name: Build the Sandbox app.
-        run: cmake --build --preset linux-sandbox
+          cmake --preset ${{ matrix.preset }} -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install
+          cmake --build --preset ${{ matrix.preset }} --target install

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,6 +13,18 @@ on:
 jobs:
   build:
     runs-on: macos-latest
+    strategy:
+      matrix:
+        library_type: [static, shared]
+        include:
+          - library_type: static
+            preset: macos
+            description: "Static Library"
+          - library_type: shared
+            preset: macos-shared
+            description: "Shared Library"
+
+    name: Build (${{ matrix.description }})
 
     steps:
       - name: Check Out
@@ -26,10 +38,7 @@ jobs:
           target: desktop
           arch: clang_64
 
-      - name: Build the library.
+      - name: Build the library (${{ matrix.description }})
         run: |
-          cmake --preset macos -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install
-          cmake --build --preset macos --target install
-
-      - name: Build the Sandbox app.
-        run: cmake --build --preset macos-sandbox
+          cmake --preset ${{ matrix.preset }} -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install
+          cmake --build --preset ${{ matrix.preset }} --target install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,6 +13,18 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+    strategy:
+      matrix:
+        library_type: [static, shared]
+        include:
+          - library_type: static
+            preset: windows
+            description: "Static Library"
+          - library_type: shared
+            preset: windows-shared
+            description: "Shared Library"
+
+    name: Build (${{ matrix.description }})
 
     steps:
       - name: Check Out
@@ -26,10 +38,10 @@ jobs:
           target: desktop
           arch: win64_msvc2022_64
 
-      - name: Build the library.
+      - name: Build the library (${{ matrix.description }})
         run: |
-          cmake --preset windows -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install
-          cmake --build --preset windows --target install
+          cmake --preset ${{ matrix.preset }} -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install
+          cmake --build --preset ${{ matrix.preset }} --target install
 
-      - name: Build the Sandbox app.
-        run: cmake --build --preset windows-sandbox
+      - name: Build the Sandbox app (${{ matrix.description }})
+        run: cmake --build --preset ${{ matrix.preset }}-sandbox

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ desktop.ini
 *.out
 *.app
 build/
-_build/
+_build*/
 Testing/
 
 # VS Code files.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,9 @@ if(NOT CMAKE_OSX_DEPLOYMENT_TARGET)
 endif()
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 
+# Include GNUInstallDirs for standard install directories
+include(GNUInstallDirs)
+
 # Find Qt.
 find_package(Qt6 REQUIRED COMPONENTS Core Widgets Svg)
 qt_standard_project_setup(

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -56,6 +56,23 @@
         "lhs": "${hostSystemName}",
         "rhs": "Linux"
       }
+    },
+    {
+      "name": "linux-shared",
+      "displayName": "Linux (Shared Library)",
+      "description": "Makefile for Linux with shared library",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/_build_shared",
+      "cacheVariables": {
+        "BUILD_SHARED_LIBS": true,
+        "QLEMENTINE_SANDBOX": true,
+        "QLEMENTINE_SHOWCASE": true
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
     }
   ],
   "buildPresets": [

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -25,6 +25,25 @@
       }
     },
     {
+      "name": "macos-shared",
+      "displayName": "macOS (Shared Library)",
+      "description": "Ninja project for macOS with shared library",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/_build_shared",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_PREFIX_PATH": "/opt/homebrew/opt/qt/lib/cmake/Qt6",
+        "BUILD_SHARED_LIBS": true,
+        "QLEMENTINE_SANDBOX": false,
+        "QLEMENTINE_SHOWCASE": false
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
       "name": "windows",
       "displayName": "Windows",
       "description": "Visual Studio project for Windows",
@@ -42,12 +61,31 @@
       }
     },
     {
+      "name": "windows-shared",
+      "displayName": "Windows (Shared Library)",
+      "description": "Visual Studio project for Windows with shared library",
+      "generator": "Visual Studio 17 2022",
+      "binaryDir": "${sourceDir}/_build_shared",
+      "cacheVariables": {
+        "CMAKE_PREFIX_PATH": "C:/Qt/6.8.2/msvc2022_64",
+        "BUILD_SHARED_LIBS": true,
+        "QLEMENTINE_SANDBOX": false,
+        "QLEMENTINE_SHOWCASE": false
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+    {
       "name": "linux",
       "displayName": "Linux",
-      "description": "Makefile for Linux",
-      "generator": "Unix Makefiles",
+      "description": "Ninja project for Linux",
+      "generator": "Ninja",
       "binaryDir": "${sourceDir}/_build",
       "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
         "QLEMENTINE_SANDBOX": true,
         "QLEMENTINE_SHOWCASE": true
       },
@@ -60,13 +98,13 @@
     {
       "name": "linux-shared",
       "displayName": "Linux (Shared Library)",
-      "description": "Makefile for Linux with shared library",
-      "generator": "Unix Makefiles",
+      "description": "Ninja project for Linux with shared library",
+      "generator": "Ninja",
       "binaryDir": "${sourceDir}/_build_shared",
       "cacheVariables": {
         "BUILD_SHARED_LIBS": true,
-        "QLEMENTINE_SANDBOX": true,
-        "QLEMENTINE_SHOWCASE": true
+        "QLEMENTINE_SANDBOX": false,
+        "QLEMENTINE_SHOWCASE": false
       },
       "condition": {
         "type": "equals",
@@ -113,6 +151,30 @@
       }
     },
     {
+      "name": "macos-shared",
+      "displayName": "macOS (Shared Library)",
+      "configurePreset": "macos-shared",
+      "description": "Build shared library with Ninja for macOS",
+      "targets": ["qlementine"],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "macos-shared-sandbox",
+      "displayName": "Sandbox for macOS (Shared Library)",
+      "configurePreset": "macos-shared",
+      "description": "Sandbox - Build with Ninja for macOS with shared library",
+      "targets": ["sandbox"],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
       "name": "windows",
       "displayName": "Windows",
       "configurePreset": "windows",
@@ -149,6 +211,30 @@
       }
     },
     {
+      "name": "windows-shared",
+      "displayName": "Windows (Shared Library)",
+      "configurePreset": "windows-shared",
+      "description": "Build shared library with Visual Studio for Windows",
+      "targets": ["qlementine"],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+    {
+      "name": "windows-shared-sandbox",
+      "displayName": "Sandbox for Windows (Shared Library)",
+      "configurePreset": "windows-shared",
+      "description": "Sandbox - Build with Visual Studio for Windows with shared library",
+      "targets": ["sandbox"],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+    {
       "name": "linux",
       "displayName": "Linux",
       "configurePreset": "linux",
@@ -178,6 +264,30 @@
       "configurePreset": "linux",
       "description": "Showcase - Build for Linux",
       "targets": ["showcase"],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+    {
+      "name": "linux-shared",
+      "displayName": "Linux (Shared Library)",
+      "configurePreset": "linux-shared",
+      "description": "Build shared library for Linux",
+      "targets": ["qlementine"],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+    {
+      "name": "linux-shared-sandbox",
+      "displayName": "Sandbox for Linux (Shared Library)",
+      "configurePreset": "linux-shared",
+      "description": "Sandbox - Build for Linux with shared library",
+      "targets": ["sandbox"],
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -6,3 +6,13 @@ include(CMakeFindDependencyMacro)
 find_dependency(Qt6 REQUIRED COMPONENTS Core Widgets Svg)
 
 check_required_components(@PROJECT_NAME@)
+
+# Set version and config path for find_package_handle_standard_args.
+# These are normally set by find_package() after sourcing the config file,
+# but we need them available now since we call FPHSA from within.
+set(@PROJECT_NAME@_VERSION "@PROJECT_VERSION@")
+set(@PROJECT_NAME@_CONFIG "${CMAKE_CURRENT_LIST_FILE}")
+
+# Produce the standard "Found <pkg>" message and properly set <pkg>_FOUND.
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(@PROJECT_NAME@ CONFIG_MODE)

--- a/cmake/qlementine.pc.in
+++ b/cmake/qlementine.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: @PROJECT_NAME@
+Description: @PROJECT_DESCRIPTION@
+Version: @PROJECT_VERSION@
+URL: https://github.com/oclero/qlementine
+Requires: Qt6Core Qt6Widgets Qt6Svg
+Libs: -L${libdir} -l@PROJECT_NAME@
+Cflags: -I${includedir}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,19 +2,54 @@
 
 ## Installation
 
-1. Add the library as a dependency. Here is an example with CMake FetchContent. You may add it with another way such as vcpkg or from a regular installation.
+### Option 1: FetchContent (Build from Source)
 
-   ```bash
+1. Add the library as a dependency using CMake FetchContent:
+
+   ```cmake
    include(FetchContent)
    FetchContent_Declare(Qlementine GIT_REPOSITORY "https://github.com/oclero/qlementine.git")
    FetchContent_MakeAvailable(Qlementine)
    ```
 
-2. Link with the library in CMake.
+2. Link with the library:
 
    ```cmake
    target_link_libraries(your_project qlementine)
    ```
+
+### Option 2: Find Installed Library
+
+If Qlementine is already installed on your system (via package manager, vcpkg, or manual installation):
+
+#### CMake
+
+```cmake
+find_package(qlementine REQUIRED)
+target_link_libraries(your_project qlementine::qlementine)
+```
+
+#### Meson
+
+```meson
+qlementine_dep = dependency('qlementine')
+executable('your_project',
+  sources: ['main.cpp'],
+  dependencies: [qlementine_dep]
+)
+```
+
+### Option 3: vcpkg
+
+```bash
+vcpkg install qlementine
+```
+
+Then in CMake:
+```cmake
+find_package(qlementine CONFIG REQUIRED)
+target_link_libraries(your_project PRIVATE qlementine::qlementine)
+```
 
 ## Usage in code
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Include GenerateExportHeader module
+include(GenerateExportHeader)
+
 # Declare files.
 set(SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/src/animation/WidgetAnimationManager.cpp
@@ -225,9 +228,19 @@ foreach(_target IN LISTS _targets_to_build)
   if(TARGET ${_target})
     message(STATUS "Configuring target: ${_target}")
 
+    # Generate export header for this target
+    generate_export_header(${_target}
+      BASE_NAME QLEMENTINE
+      EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/include/oclero/qlementine/qlementine_export.h
+      EXPORT_MACRO_NAME QLEMENTINE_EXPORT
+      NO_EXPORT_MACRO_NAME QLEMENTINE_NO_EXPORT
+      STATIC_DEFINE QLEMENTINE_STATIC_DEFINE
+    )
+
     target_include_directories(${_target}
       PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
       PRIVATE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
@@ -306,6 +319,10 @@ install(TARGETS ${_targets_to_build}
 
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/"
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+
+# Install the generated export header
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/include/oclero/qlementine/qlementine_export.h"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/oclero/qlementine/")
 
 install(EXPORT "${PROJECT_NAME}Targets"
   FILE "${PROJECT_NAME}Targets.cmake"

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -112,47 +112,141 @@ set(RESOURCES
   resources/qlementine_font_roboto.qrc
 )
 
-# Create target.
-qt_add_library(${PROJECT_NAME} STATIC
-  ${HEADERS}
-  ${SOURCES}
-  ${RESOURCES}
-)
-include(CMakePackageConfigHelpers)
+option(BUILD_SHARED_LIBS "Build shared libraries instead of static" OFF)
+option(QLEMENTINE_BUILD_STATIC "Build static library alongside shared (when BUILD_SHARED_LIBS=ON)" OFF)
 
-target_include_directories(${PROJECT_NAME}
-  PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-  PRIVATE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-)
+set(_build_shared ${BUILD_SHARED_LIBS})
+set(_build_static ON)  # Always build static unless only shared is requested
 
-target_link_libraries(${PROJECT_NAME}
-  PUBLIC
-    Qt::Core
-    Qt::Widgets
-    Qt::Svg
-)
+if(BUILD_SHARED_LIBS AND NOT QLEMENTINE_BUILD_STATIC)
+  set(_build_static OFF)  # Only shared
+endif()
 
-set_target_properties(${PROJECT_NAME}
-  PROPERTIES
-    OUTPUT_NAME ${PROJECT_NAME}
-    PROJECT_LABEL ${PROJECT_NAME}
-    FOLDER lib
-    SOVERSION ${PROJECT_VERSION_MAJOR}
-    VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
-    DEBUG_POSTFIX _debug
-    CMAKE_AUTORCC ON
-    CMAKE_AUTOMOC ON
-    CMAKE_AUTOUIC ON
-)
+# Initialize target variables
+set(_targets_to_build)
+set(_main_target_name ${PROJECT_NAME})
 
-target_compile_options(${PROJECT_NAME}
-  PRIVATE
-    $<$<CXX_COMPILER_ID:MSVC>:/MP /WX /W4>
-    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Werror>
-)
+# Create shared library target
+if(_build_shared)
+  set(_shared_target "${PROJECT_NAME}_shared")
+  if(NOT _build_static)
+    # If only shared, use the main project name
+    set(_shared_target ${PROJECT_NAME})
+  endif()
+
+  qt_add_library(${_shared_target} SHARED
+    ${HEADERS}
+    ${SOURCES}
+    ${RESOURCES}
+  )
+
+  # Set shared library specific properties
+  set_target_properties(${_shared_target}
+    PROPERTIES
+      OUTPUT_NAME ${PROJECT_NAME}
+      PROJECT_LABEL "${PROJECT_NAME}_Shared"
+      FOLDER lib
+      SOVERSION ${PROJECT_VERSION_MAJOR}
+      VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+      DEBUG_POSTFIX _debug
+      CMAKE_AUTORCC ON
+      CMAKE_AUTOMOC ON
+      CMAKE_AUTOUIC ON
+      # Use C++ visibility attributes for symbol export
+      CXX_VISIBILITY_PRESET default
+      VISIBILITY_INLINES_HIDDEN ON
+  )
+
+  list(APPEND _targets_to_build ${_shared_target})
+
+  # Create alias for shared library
+  if(_build_static)
+    add_library(${PROJECT_NAME}::shared ALIAS ${_shared_target})
+  else()
+    # If only shared, this is the main target
+    add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${_shared_target})
+    set(_main_target_name ${_shared_target})
+  endif()
+endif()
+
+# Create static library target
+if(_build_static)
+  set(_static_target "${PROJECT_NAME}_static")
+  if(NOT _build_shared)
+    # If only static, use the main project name
+    set(_static_target ${PROJECT_NAME})
+  endif()
+
+  qt_add_library(${_static_target} STATIC
+    ${HEADERS}
+    ${SOURCES}
+    ${RESOURCES}
+  )
+
+  # Set static library specific properties
+  set_target_properties(${_static_target}
+    PROPERTIES
+      OUTPUT_NAME ${PROJECT_NAME}
+      PROJECT_LABEL "${PROJECT_NAME}_Static"
+      FOLDER lib
+      DEBUG_POSTFIX _debug
+      CMAKE_AUTORCC ON
+      CMAKE_AUTOMOC ON
+      CMAKE_AUTOUIC ON
+  )
+
+  list(APPEND _targets_to_build ${_static_target})
+
+  # Create alias for static library
+  if(_build_shared)
+    add_library(${PROJECT_NAME}::static ALIAS ${_static_target})
+  else()
+    # If only static, this is the main target
+    add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${_static_target})
+    set(_main_target_name ${_static_target})
+  endif()
+endif()
+
+# Create the main alias that apps will link against
+# This always points to the "preferred" target (shared if available, otherwise static)
+if(_build_shared)
+  if(NOT TARGET ${PROJECT_NAME})
+    # Create an alias from the plain name to the shared target
+    add_library(${PROJECT_NAME} ALIAS ${_shared_target})
+  endif()
+else()
+  # For static-only builds, the plain name already exists as the target
+  if(NOT TARGET ${PROJECT_NAME})
+    add_library(${PROJECT_NAME} ALIAS ${_static_target})
+  endif()
+endif()
+# Configure all targets (shared and/or static)
+foreach(_target IN LISTS _targets_to_build)
+  if(TARGET ${_target})
+    message(STATUS "Configuring target: ${_target}")
+
+    target_include_directories(${_target}
+      PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+      PRIVATE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+    )
+
+    target_link_libraries(${_target}
+      PUBLIC
+        Qt::Core
+        Qt::Widgets
+        Qt::Svg
+    )
+
+    target_compile_options(${_target}
+      PRIVATE
+        $<$<CXX_COMPILER_ID:MSVC>:/MP /WX /W4>
+        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Werror>
+    )
+  endif()
+endforeach()
 
 # Create source groups.
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}
@@ -166,7 +260,20 @@ if(WIN32)
   set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT ${PROJECT_NAME})
 endif()
 
-# Install target
+# Create source groups.
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}
+  FILES
+    ${HEADERS}
+    ${SOURCES}
+)
+
+# Select correct startup project in Visual Studio.
+if(WIN32)
+  set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT ${PROJECT_NAME})
+endif()
+
+# CMake package configuration
+include(CMakePackageConfigHelpers)
 configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/../cmake/config.cmake.in"
   "${CMAKE_BINARY_DIR}/cmake/${PROJECT_NAME}Config.cmake"
   INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
@@ -175,7 +282,22 @@ write_basic_package_version_file("${CMAKE_BINARY_DIR}/cmake/${PROJECT_NAME}Confi
   VERSION "${PROJECT_VERSION}"
   COMPATIBILITY AnyNewerVersion)
 
-install(TARGETS ${PROJECT_NAME}
+# Generate pkgconfig file on supported platforms
+if(UNIX OR MINGW)
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/qlementine.pc.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/qlementine.pc"
+    @ONLY
+  )
+
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/qlementine.pc"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+    COMPONENT Development
+  )
+endif()
+
+# Install targets
+install(TARGETS ${_targets_to_build}
   EXPORT "${PROJECT_NAME}Targets"
   LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
   ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"

--- a/lib/include/oclero/qlementine/animation/WidgetAnimationManager.hpp
+++ b/lib/include/oclero/qlementine/animation/WidgetAnimationManager.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <oclero/qlementine/animation/WidgetAnimator.hpp>
+#include <oclero/qlementine/qlementine_export.h>
 
 #include <unordered_map>
 #include <optional>
@@ -29,7 +30,7 @@ namespace oclero::qlementine {
   }
 
 // Handles animations for all widgets.
-class WidgetAnimationManager {
+class QLEMENTINE_EXPORT WidgetAnimationManager {
 public:
   WidgetAnimationManager();
 

--- a/lib/include/oclero/qlementine/animation/WidgetAnimator.hpp
+++ b/lib/include/oclero/qlementine/animation/WidgetAnimator.hpp
@@ -5,6 +5,7 @@
 
 #include <oclero/qlementine/animation/WidgetAnimation.hpp>
 #include <oclero/qlementine/style/Theme.hpp>
+#include <oclero/qlementine/qlementine_export.h>
 
 #include <QObject>
 #include <QEvent>
@@ -46,7 +47,7 @@ public: \
     get##NAME##Animation().setLoopEnabled(loop); \
   }
 
-class WidgetAnimator : public QObject {
+class QLEMENTINE_EXPORT WidgetAnimator : public QObject {
 public:
   explicit WidgetAnimator(QWidget* parent)
     : QObject(parent)

--- a/lib/include/oclero/qlementine/style/QlementineStyle.hpp
+++ b/lib/include/oclero/qlementine/style/QlementineStyle.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
 #include <oclero/qlementine/style/Theme.hpp>
 #include <oclero/qlementine/utils/ImageUtils.hpp>
 #include <oclero/qlementine/utils/IconUtils.hpp>
@@ -17,7 +18,7 @@ class CommandLinkButtonPaintEventFilter;
 class LineEditButtonEventFilter;
 struct QlementineStyleImpl;
 
-class QlementineStyle : public QCommonStyle {
+class QLEMENTINE_EXPORT QlementineStyle : public QCommonStyle {
   Q_OBJECT
 
   Q_PROPERTY(bool animationsEnabled READ animationsEnabled WRITE setAnimationsEnabled NOTIFY animationsEnabledChanged)
@@ -293,5 +294,5 @@ private:
   std::unique_ptr<QlementineStyleImpl> _impl;
 };
 
-QlementineStyle* appStyle();
+QLEMENTINE_EXPORT QlementineStyle* appStyle();
 } // namespace oclero::qlementine

--- a/lib/include/oclero/qlementine/style/Theme.hpp
+++ b/lib/include/oclero/qlementine/style/Theme.hpp
@@ -5,6 +5,7 @@
 
 #include <optional>
 
+#include <oclero/qlementine/qlementine_export.h>
 #include <oclero/qlementine/Common.hpp>
 
 #include <QString>
@@ -31,7 +32,7 @@ struct ThemeMeta {
 };
 
 /// Color and sizes configuration for a Qlementine Theme.
-class Theme {
+class QLEMENTINE_EXPORT Theme {
 public: // Ctor.
   Theme();
 

--- a/lib/include/oclero/qlementine/style/ThemeManager.hpp
+++ b/lib/include/oclero/qlementine/style/ThemeManager.hpp
@@ -8,11 +8,12 @@
 
 #include <vector>
 
+#include <oclero/qlementine/qlementine_export.h>
 #include <oclero/qlementine/style/Theme.hpp>
 #include <oclero/qlementine/style/QlementineStyle.hpp>
 
 namespace oclero::qlementine {
-class ThemeManager : public QObject {
+class QLEMENTINE_EXPORT ThemeManager : public QObject {
   Q_OBJECT
 
   Q_PROPERTY(QString currentTheme READ currentTheme WRITE setCurrentTheme NOTIFY currentThemeChanged)

--- a/lib/include/oclero/qlementine/tools/ThemeEditor.hpp
+++ b/lib/include/oclero/qlementine/tools/ThemeEditor.hpp
@@ -6,10 +6,11 @@
 #include <memory>
 #include <QWidget>
 
+#include <oclero/qlementine/qlementine_export.h>
 #include <oclero/qlementine/style/Theme.hpp>
 
 namespace oclero::qlementine {
-class ThemeEditor : public QWidget {
+class QLEMENTINE_EXPORT ThemeEditor : public QWidget {
   Q_OBJECT
 
 public:

--- a/lib/include/oclero/qlementine/utils/ColorUtils.hpp
+++ b/lib/include/oclero/qlementine/utils/ColorUtils.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
+
 #include <QVariant>
 #include <QColor>
 #include <optional>
@@ -10,35 +12,35 @@
 namespace oclero::qlementine {
 
 /// Computes the contrast ratio between the two colors, according to w3.org spec.
-double getContrastRatio(const QColor& c1, const QColor& c2);
+QLEMENTINE_EXPORT double getContrastRatio(const QColor& c1, const QColor& c2);
 
 /// Gets the color with the new alpha channel (from 0.0 to 1.0).
-QColor colorWithAlphaF(QColor const& color, qreal alpha);
+QLEMENTINE_EXPORT QColor colorWithAlphaF(QColor const& color, qreal alpha);
 
 /// Gets the color the new alpha chanel (from 0 to 255).
-QColor colorWithAlpha(QColor const& color, int alpha);
+QLEMENTINE_EXPORT QColor colorWithAlpha(QColor const& color, int alpha);
 
 /// Gets the resulting color by applying the foreground color over the background color with 'SourceOver' composition mode.
-QColor getColorSourceOver(const QColor& bg, const QColor& fg);
+QLEMENTINE_EXPORT QColor getColorSourceOver(const QColor& bg, const QColor& fg);
 
 /// Attempts to parse the QVariant array to get a QColor from the array's values.
 /// The order is R, G, B, A.
-std::optional<QColor> tryGetColorFromVariantList(QVariantList const& variantList);
+QLEMENTINE_EXPORT std::optional<QColor> tryGetColorFromVariantList(QVariantList const& variantList);
 
 ///  Attempts to parse the QString to get a QColor from the string's values.
 /// The string must follow this rule: "R,G,B,A" (spaces are ignored).
-std::optional<QColor> tryGetColorFromRGBAString(QString const& str);
+QLEMENTINE_EXPORT std::optional<QColor> tryGetColorFromRGBAString(QString const& str);
 
 /// Attempts to parse the QString to get a QColor from the string's values.
 /// The string must follow this rule: "#RRGGBBAA" (AA is facultative, spaces are ignored).
-std::optional<QColor> tryGetColorFromHexaString(QString const& str);
+QLEMENTINE_EXPORT std::optional<QColor> tryGetColorFromHexaString(QString const& str);
 
 /// Attempts to parse the QVariant to get a QColor.
-std::optional<QColor> tryGetColorFromVariant(QVariant const& variant);
+QLEMENTINE_EXPORT std::optional<QColor> tryGetColorFromVariant(QVariant const& variant);
 
 /// Gives the color's hexadecimal RGB string.
-QString toHexRGB(const QColor& color);
+QLEMENTINE_EXPORT QString toHexRGB(const QColor& color);
 
 /// Gives the color's hexadecimal RGBA string.
-QString toHexRGBA(const QColor& color);
+QLEMENTINE_EXPORT QString toHexRGBA(const QColor& color);
 } // namespace oclero::qlementine

--- a/lib/include/oclero/qlementine/utils/FontUtils.hpp
+++ b/lib/include/oclero/qlementine/utils/FontUtils.hpp
@@ -3,14 +3,16 @@
 
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
+
 #include <QString>
 #include <QFontMetrics>
 
 namespace oclero::qlementine {
 
-double pointSizeToPixelSize(double pointSize, double dpi);
+QLEMENTINE_EXPORT double pointSizeToPixelSize(double pointSize, double dpi);
 
-double pixelSizeToPointSize(double pixelSize, double dpi);
+QLEMENTINE_EXPORT double pixelSizeToPointSize(double pixelSize, double dpi);
 
 /**
  * @brief An utility to centralize the calls to QFontMetrics.
@@ -18,5 +20,5 @@ double pixelSizeToPointSize(double pixelSize, double dpi);
  * @param text The text to compute the width for.
  * @return The width of the text in logical pixels.
  */
-int textWidth(const QFontMetrics& fm, const QString& text);
+QLEMENTINE_EXPORT int textWidth(const QFontMetrics& fm, const QString& text);
 } // namespace oclero::qlementine

--- a/lib/include/oclero/qlementine/utils/IconUtils.hpp
+++ b/lib/include/oclero/qlementine/utils/IconUtils.hpp
@@ -3,11 +3,13 @@
 
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
+
 #include <QIcon>
 #include <QColor>
 
 namespace oclero::qlementine {
-struct IconTheme {
+struct QLEMENTINE_EXPORT IconTheme {
   QColor normal;
   QColor disabled;
   QColor checkedNormal;
@@ -21,9 +23,9 @@ struct IconTheme {
 };
 
 /// Makes an icon from the file located at the path in parameter. Fixes the standard Qt behavior.
-[[maybe_unused]] QIcon makeIconFromSvg(const QString& svgPath, const QSize& size);
+[[maybe_unused]] QLEMENTINE_EXPORT QIcon makeIconFromSvg(const QString& svgPath, const QSize& size);
 
 /// Makes an icon from the file located at the path in parameter and colorizes the QPixmaps. Fixes the standard Qt behavior.
-[[maybe_unused]] QIcon makeIconFromSvg(
+[[maybe_unused]] QLEMENTINE_EXPORT QIcon makeIconFromSvg(
   const QString& svgPath, const IconTheme& iconTheme, const QSize& size = QSize(16, 16));
 } // namespace oclero::qlementine

--- a/lib/include/oclero/qlementine/utils/ImageUtils.hpp
+++ b/lib/include/oclero/qlementine/utils/ImageUtils.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
 #include <oclero/qlementine/utils/RadiusesF.hpp>
 
 #include <QPixmap>
@@ -32,31 +33,31 @@ QString toHex(T const i, bool const prefix = false) {
 }
 
 /// Basically colorize the QPixmap and returns a QImage.
-QImage colorizeImage(QPixmap const& input, QColor const& color);
+QLEMENTINE_EXPORT QImage colorizeImage(QPixmap const& input, QColor const& color);
 
 /// Basically colorize the QPixmap.
-QPixmap colorizePixmap(QPixmap const& input, QColor const& color);
+QLEMENTINE_EXPORT QPixmap colorizePixmap(QPixmap const& input, QColor const& color);
 
 /// Tints the QPixmap, preserving contrast between shades.
-QPixmap tintPixmap(QPixmap const& input, QColor const& color);
+QLEMENTINE_EXPORT QPixmap tintPixmap(QPixmap const& input, QColor const& color);
 
 /// Looks for a colorized version of the input pixmap in the cache.
 /// If not existing, generates it and adds it to the cache.
 /// Else, just returns the existing pixmap.
 /// If any error, returns the input pixmap.
-QPixmap getColorizedPixmap(QPixmap const& input, QColor const& color);
+QLEMENTINE_EXPORT QPixmap getColorizedPixmap(QPixmap const& input, QColor const& color);
 
 /// Looks for a tinted version of the input pixmap in the cache.
 /// If not existing, generates it and adds it to the cache.
 /// Else, just returns the existing pixmap.
 /// If any error, returns the input pixmap.
-QPixmap getTintedPixmap(QPixmap const& input, QColor const& color);
+QLEMENTINE_EXPORT QPixmap getTintedPixmap(QPixmap const& input, QColor const& color);
 
 /// Gets the key to use in the QPixmapCache.
-QString getColorizedPixmapKey(QPixmap const& pixmap, QColor const& color);
+QLEMENTINE_EXPORT QString getColorizedPixmapKey(QPixmap const& pixmap, QColor const& color);
 
 /// Gets the key to use in the QPixmapCache.
-QString getTintedPixmapKey(QPixmap const& pixmap, QColor const& color);
+QLEMENTINE_EXPORT QString getTintedPixmapKey(QPixmap const& pixmap, QColor const& color);
 
 /// Type of effect applied to colorize the image.
 enum class ColorizeMode {
@@ -80,47 +81,47 @@ enum class AutoIconColor {
 };
 
 /// Gets the pixmap in the cache, or creates it if not yet there.
-QPixmap getCachedPixmap(QPixmap const& input, QColor const& color, ColorizeMode mode);
+QLEMENTINE_EXPORT QPixmap getCachedPixmap(QPixmap const& input, QColor const& color, ColorizeMode mode);
 
 /// Makes a QPixmap from the file located at the path in parameter at the desired size.
-QPixmap makePixmapFromSvg(const QString& svgPath, const QSize& size);
+QLEMENTINE_EXPORT QPixmap makePixmapFromSvg(const QString& svgPath, const QSize& size);
 
 /// Makes a QPixmap from the file located at the path in parameter at the desired size.
-QPixmap makePixmapFromSvg(const QString& backgroundSvgPath, const QColor& backgroundSvgColor,
+QLEMENTINE_EXPORT QPixmap makePixmapFromSvg(const QString& backgroundSvgPath, const QColor& backgroundSvgColor,
   const QString& foregroundSvgPath, const QColor& foregroundSvgColor, const QSize& size);
 
 /// Makes a QPixmap with rounded corners.
-QPixmap makeRoundedPixmap(QPixmap const& input, double radius);
+QLEMENTINE_EXPORT QPixmap makeRoundedPixmap(QPixmap const& input, double radius);
 
 /// Makes a QPixmap with rounded corners.
-QPixmap makeRoundedPixmap(QPixmap const& input, const RadiusesF& radiuses);
+QLEMENTINE_EXPORT QPixmap makeRoundedPixmap(QPixmap const& input, const RadiusesF& radiuses);
 
 /// Makes a QPixmap with rounded corners.
-QPixmap makeRoundedPixmap(QPixmap const& input, double topLeft, double topRight, double bottomRight, double bottomLeft);
+QLEMENTINE_EXPORT QPixmap makeRoundedPixmap(QPixmap const& input, double topLeft, double topRight, double bottomRight, double bottomLeft);
 
 /// Makes a pixmap that fits the requested size.
-QPixmap makeFitPixmap(QPixmap const& input, const QSize& size);
+QLEMENTINE_EXPORT QPixmap makeFitPixmap(QPixmap const& input, const QSize& size);
 
 /// Gets the aspect ratio (width by height) of the image, without loading it into memory.
-double getImageAspectRatio(QString const& path);
+QLEMENTINE_EXPORT double getImageAspectRatio(QString const& path);
 
 /// Gets a version of the pixmap with padding around.
-QImage getExtendedImage(QPixmap const& input, int padding);
+QLEMENTINE_EXPORT QImage getExtendedImage(QPixmap const& input, int padding);
 
 /// Gets a version of the image with padding around.
-QImage getExtendedImage(QImage const& input, int padding);
+QLEMENTINE_EXPORT QImage getExtendedImage(QImage const& input, int padding);
 
 /// Gets a blurred version of the input pixmap
-QPixmap getBlurredPixmap(QPixmap const& input, double blurRadius);
+QLEMENTINE_EXPORT QPixmap getBlurredPixmap(QPixmap const& input, double blurRadius);
 
 /// Gets a drop shadow for the input pixmap (i.e. a blurred colorized version).
-QPixmap getDropShadowPixmap(QPixmap const& input, double blurRadius, QColor const& color = Qt::black);
+QLEMENTINE_EXPORT QPixmap getDropShadowPixmap(QPixmap const& input, double blurRadius, QColor const& color = Qt::black);
 
 /// Gets a drop shadow for a QRect.
-QPixmap getDropShadowPixmap(QSize const& size, double borderRadius, double blurRadius, QColor const& color = Qt::black);
+QLEMENTINE_EXPORT QPixmap getDropShadowPixmap(QSize const& size, double borderRadius, double blurRadius, QColor const& color = Qt::black);
 
 /// Calculates the necessary space for a blurred image.
-int blurRadiusNecessarySpace(const double blurRadius);
+QLEMENTINE_EXPORT int blurRadiusNecessarySpace(const double blurRadius);
 } // namespace oclero::qlementine
 
 Q_DECLARE_METATYPE(oclero::qlementine::AutoIconColor);

--- a/lib/include/oclero/qlementine/utils/LayoutUtils.hpp
+++ b/lib/include/oclero/qlementine/utils/LayoutUtils.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
+
 #include <QMargins>
 #include <QLayout>
 
@@ -12,23 +14,23 @@ class QWidget;
 
 namespace oclero::qlementine {
 /// Retrieves the widget's QStyle margins.
-QMargins getLayoutMargins(const QWidget* widget);
+QLEMENTINE_EXPORT QMargins getLayoutMargins(const QWidget* widget);
 
 /// Retrieves the widget's QStyle horizontal spacing.
-int getLayoutHSpacing(const QWidget* widget);
+QLEMENTINE_EXPORT int getLayoutHSpacing(const QWidget* widget);
 
 /// Retrieves the widget's QStyle vertical spacing.
-int getLayoutVSpacing(const QWidget* widget);
+QLEMENTINE_EXPORT int getLayoutVSpacing(const QWidget* widget);
 
 /// Retrieves the widget's QStyle horizontal spacing and margins.
-std::tuple<int, QMargins> getHLayoutProps(const QWidget* widget);
+QLEMENTINE_EXPORT std::tuple<int, QMargins> getHLayoutProps(const QWidget* widget);
 
 /// Retrieves the widget's QStyle vertical spacing and margins.
-std::tuple<int, QMargins> getVLayoutProps(const QWidget* widget);
+QLEMENTINE_EXPORT std::tuple<int, QMargins> getVLayoutProps(const QWidget* widget);
 
 /// Retrieves the widget's QStyle vertical/horizontal spacings and margins.
-std::tuple<int, int, QMargins> getFormLayoutProps(const QWidget* widget);
+QLEMENTINE_EXPORT std::tuple<int, int, QMargins> getFormLayoutProps(const QWidget* widget);
 
 /// Remove and deletes all the elements in the layout.
-void clearLayout(QLayout* layout);
+QLEMENTINE_EXPORT void clearLayout(QLayout* layout);
 } // namespace oclero::qlementine

--- a/lib/include/oclero/qlementine/utils/MenuUtils.hpp
+++ b/lib/include/oclero/qlementine/utils/MenuUtils.hpp
@@ -5,11 +5,13 @@
 
 #include <functional>
 
+#include <oclero/qlementine/qlementine_export.h>
+
 class QMenu;
 class QAction;
 
 namespace oclero::qlementine {
-QMenu* getTopLevelMenu(QMenu* menu);
+QLEMENTINE_EXPORT QMenu* getTopLevelMenu(QMenu* menu);
 
-void flashAction(QAction* action, QMenu* menu, const std::function<void()>& onAnimationFinished);
+QLEMENTINE_EXPORT void flashAction(QAction* action, QMenu* menu, const std::function<void()>& onAnimationFinished);
 } // namespace oclero::qlementine

--- a/lib/include/oclero/qlementine/utils/PrimitiveUtils.hpp
+++ b/lib/include/oclero/qlementine/utils/PrimitiveUtils.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
 #include <oclero/qlementine/style/QlementineStyle.hpp>
 #include <oclero/qlementine/utils/RadiusesF.hpp>
 
@@ -17,229 +18,229 @@ namespace oclero::qlementine {
 [[maybe_unused]] static constexpr auto QLEMENTINE_PI = 3.14159265358979323846;
 
 /// Gets the device pixel ratio for the QWidget.
-double getPixelRatio(QWidget const* w);
+QLEMENTINE_EXPORT double getPixelRatio(QWidget const* w);
 
 /// Parses the text to detect the MenuItem's label and shortcut, usually separated by a tab.
-std::tuple<QString, QString> getMenuLabelAndShortcut(QString const& text);
+QLEMENTINE_EXPORT std::tuple<QString, QString> getMenuLabelAndShortcut(QString const& text);
 
 /// Draws an antialiased pixel-perfect border for the ellipsis.
-void drawEllipseBorder(QPainter* p, QRectF const& rect, QColor const& color, qreal const borderWidth);
+QLEMENTINE_EXPORT void drawEllipseBorder(QPainter* p, QRectF const& rect, QColor const& color, qreal const borderWidth);
 
 /// Generates a QPainterPath that contains a rounded rectangle with different radiuses for each angle.
-QPainterPath getMultipleRadiusesRectPath(QRectF const& rect, RadiusesF const& radiuses);
+QLEMENTINE_EXPORT QPainterPath getMultipleRadiusesRectPath(QRectF const& rect, RadiusesF const& radiuses);
 
 /// Draws an antialiased rect.
-void drawRoundedRect(QPainter* p, QRectF const& rect, QBrush const& brush, qreal const radius = 0.);
+QLEMENTINE_EXPORT void drawRoundedRect(QPainter* p, QRectF const& rect, QBrush const& brush, qreal const radius = 0.);
 
-/// Draws an antialiased rect with different radiuses.
-void drawRoundedRect(QPainter* p, QRectF const& rect, QBrush const& brush, RadiusesF const& radiuses);
+// Draws an antialiased rect with different radiuses.
+QLEMENTINE_EXPORT void drawRoundedRect(QPainter* p, QRectF const& rect, QBrush const& brush, RadiusesF const& radiuses);
 
 /// Draws an antialiased rect.
-void drawRoundedRect(QPainter* p, QRect const& rect, QBrush const& brush, qreal const radius = 0.);
+QLEMENTINE_EXPORT void drawRoundedRect(QPainter* p, QRect const& rect, QBrush const& brush, qreal const radius = 0.);
 
-/// Draws an antialiased rect with different radiuses.
-void drawRoundedRect(QPainter* p, QRect const& rect, QBrush const& brush, RadiusesF const& radiuses);
+// Draws an antialiased rect with different radiuses.
+QLEMENTINE_EXPORT void drawRoundedRect(QPainter* p, QRect const& rect, QBrush const& brush, RadiusesF const& radiuses);
 
 /// Draws an antialiased pixel-perfect border for the rounded rect.
-void drawRoundedRectBorder(
+QLEMENTINE_EXPORT void drawRoundedRectBorder(
   QPainter* p, QRectF const& rect, QColor const& color, qreal const borderWidth, qreal const radius = 0.);
 
 /// Draws an antialiased pixel-perfect border for the rounded rect.
-void drawRoundedRectBorder(
+QLEMENTINE_EXPORT void drawRoundedRectBorder(
   QPainter* p, QRect const& rect, QColor const& color, qreal const borderWidth, qreal const radius = 0.);
 
 /// Draws an antialiased pixel-perfect border for the rounded rect.
-void drawRoundedRectBorder(
+QLEMENTINE_EXPORT void drawRoundedRectBorder(
   QPainter* p, QRectF const& rect, QColor const& color, qreal const borderWidth, RadiusesF const& radiuses = {});
 
 /// Draws an antialiased pixel-perfect border for the rounded rect.
-void drawRoundedRectBorder(
+QLEMENTINE_EXPORT void drawRoundedRectBorder(
   QPainter* p, QRect const& rect, QColor const& color, qreal const borderWidth, RadiusesF const& radiuses = {});
 
 /// Draws a pixel-perfect border for the rect.
-void drawRectBorder(QPainter* p, QRect const& rect, QColor const& color, qreal const borderWidth);
+QLEMENTINE_EXPORT void drawRectBorder(QPainter* p, QRect const& rect, QColor const& color, qreal const borderWidth);
 
 /// Draws a pixel-perfect border for the rect.
-void drawRectBorder(QPainter* p, QRectF const& rect, QColor const& color, qreal const borderWidth);
+QLEMENTINE_EXPORT void drawRectBorder(QPainter* p, QRectF const& rect, QColor const& color, qreal const borderWidth);
 
 /// Draws an antialiased triangle.
-void drawRoundedTriangle(QPainter* p, QRectF const& rect, qreal const radius = 0.);
+QLEMENTINE_EXPORT void drawRoundedTriangle(QPainter* p, QRectF const& rect, qreal const radius = 0.);
 
 /// Draws a checkerboard texture.
-void drawCheckerboard(
+QLEMENTINE_EXPORT void drawCheckerboard(
   QPainter* p, const QRectF& rect, const QColor& darkColor, const QColor& lightColor, const qreal cellWidth);
 
 /// Draws the value of a progress bar. A clipping mask is used to ensure the rectangle radiuses are respected
 /// even for values close to min or max.
-void drawProgressBarValueRect(QPainter* p, QRect const& rect, QColor const& color, qreal min, qreal max, qreal value,
+QLEMENTINE_EXPORT void drawProgressBarValueRect(QPainter* p, QRect const& rect, QColor const& color, qreal min, qreal max, qreal value,
   qreal const radius = 0., bool inverted = false);
 
 /// Draws a color mark. Will draw a border if the contrast between color and background is not high enough.
-void drawColorMark(QPainter* p, QRect const& rect, const QColor& color, const QColor& borderColor, int borderWidth = 1);
+QLEMENTINE_EXPORT void drawColorMark(QPainter* p, QRect const& rect, const QColor& color, const QColor& borderColor, int borderWidth = 1);
 
 /// Draws the border of a color mark.
-void drawColorMarkBorder(QPainter* p, QRect const& rect, const QColor& borderColor, int borderWidth);
+QLEMENTINE_EXPORT void drawColorMarkBorder(QPainter* p, QRect const& rect, const QColor& borderColor, int borderWidth);
 
 /// Draws a semi-transparent red rectangle.
-void drawDebugRect(const QRect& rect, QPainter* p);
+QLEMENTINE_EXPORT void drawDebugRect(const QRect& rect, QPainter* p);
 
 /// Function that draws and generates a QPixmap.
 using PixmapMakerFunc = std::function<QPixmap(const QSize& s, const QColor& c)>;
 
 /// Utility to add QPixmaps to all states of the QIcon. The callback in parameter will be called to draw each QPixmap.
-void updateUncheckableButtonIconPixmap(QIcon& icon, const QSize& size, Theme const& theme, const PixmapMakerFunc& func);
+QLEMENTINE_EXPORT void updateUncheckableButtonIconPixmap(QIcon& icon, const QSize& size, Theme const& theme, const PixmapMakerFunc& func);
 
 /// Gets the path to draw the menu arrow in a Button.
-QPainterPath getMenuIndicatorPath(const QRect& rect);
+QLEMENTINE_EXPORT QPainterPath getMenuIndicatorPath(const QRect& rect);
 
 /// Draws the combobox double arrow.
-void drawComboBoxIndicator(const QRect& rect, QPainter* p);
+QLEMENTINE_EXPORT void drawComboBoxIndicator(const QRect& rect, QPainter* p);
 
 /// Draws the checkbox indicator (i.e. a check mark).
-void drawCheckBoxIndicator(const QRect& rect, QPainter* p, qreal progress = 1.);
+QLEMENTINE_EXPORT void drawCheckBoxIndicator(const QRect& rect, QPainter* p, qreal progress = 1.);
 
 /// Draws the partially checked checkbox indicator (i.e. a dash).
-void drawPartiallyCheckedCheckBoxIndicator(const QRect& rect, QPainter* p, qreal progress = 1.);
+QLEMENTINE_EXPORT void drawPartiallyCheckedCheckBoxIndicator(const QRect& rect, QPainter* p, qreal progress = 1.);
 
 /// Draws the radiobutton indicator (i.e. a circle).
-void drawRadioButtonIndicator(const QRect& rect, QPainter* p, qreal progress = 1.);
+QLEMENTINE_EXPORT void drawRadioButtonIndicator(const QRect& rect, QPainter* p, qreal progress = 1.);
 
 /// Draws a spinbox up/down indicator (i.e. +/- or up/down arrow).
-void drawSpinBoxArrowIndicator(const QRect& rect, QPainter* p, QAbstractSpinBox::ButtonSymbols buttonSymbol,
+QLEMENTINE_EXPORT void drawSpinBoxArrowIndicator(const QRect& rect, QPainter* p, QAbstractSpinBox::ButtonSymbols buttonSymbol,
   QStyle::SubControl subControl, QSize const& iconSize);
 
 /// Draws an arrow that points to the right.
-void drawArrowRight(const QRect& rect, QPainter* p);
+QLEMENTINE_EXPORT void drawArrowRight(const QRect& rect, QPainter* p);
 
 /// Draws an arrow that points to the left.
-void drawArrowLeft(const QRect& rect, QPainter* p);
+QLEMENTINE_EXPORT void drawArrowLeft(const QRect& rect, QPainter* p);
 
 /// Draws an arrow that points down.
-void drawArrowDown(const QRect& rect, QPainter* p);
+QLEMENTINE_EXPORT void drawArrowDown(const QRect& rect, QPainter* p);
 
 /// Draws an arrow that points up.
-void drawArrowUp(const QRect& rect, QPainter* p);
+QLEMENTINE_EXPORT void drawArrowUp(const QRect& rect, QPainter* p);
 
 /// Draws the sub-menu arrow.
-void drawSubMenuIndicator(const QRect& rect, QPainter* p);
+QLEMENTINE_EXPORT void drawSubMenuIndicator(const QRect& rect, QPainter* p);
 
 /// Draws a double right arrow.
-void drawDoubleArrowRightIndicator(const QRect& rect, QPainter* p);
+QLEMENTINE_EXPORT void drawDoubleArrowRightIndicator(const QRect& rect, QPainter* p);
 
 /// Draws a small double right arrow.
-void drawToolBarExtensionIndicator(const QRect& rect, QPainter* p);
+QLEMENTINE_EXPORT void drawToolBarExtensionIndicator(const QRect& rect, QPainter* p);
 
 /// Draws a close indicator (i.e. the cross).
-void drawCloseIndicator(const QRect& rect, QPainter* p);
+QLEMENTINE_EXPORT void drawCloseIndicator(const QRect& rect, QPainter* p);
 
 /// Draws a treeview indicator.
-void drawTreeViewIndicator(const QRect& rect, QPainter* p, bool open);
+QLEMENTINE_EXPORT void drawTreeViewIndicator(const QRect& rect, QPainter* p, bool open);
 
 /// Draws a calendar indicator (e.g. for the widgets that display a calendar popup).
-void drawCalendarIndicator(const QRect& rect, QPainter* p, const QColor& color);
+QLEMENTINE_EXPORT void drawCalendarIndicator(const QRect& rect, QPainter* p, const QColor& color);
 
 /// Draws a grip indicator (for drag n' drop).
-void drawGripIndicator(const QRect& rect, QPainter* p, const QColor& color, Qt::Orientation orientation);
+QLEMENTINE_EXPORT void drawGripIndicator(const QRect& rect, QPainter* p, const QColor& color, Qt::Orientation orientation);
 
 /// Gets the tick interval according to the length of steps, range and available length.
-int getTickInterval(int tickInterval, int singleStep, int pageStep, int min, int max, int sliderLength);
+QLEMENTINE_EXPORT int getTickInterval(int tickInterval, int singleStep, int pageStep, int min, int max, int sliderLength);
 
 /// Draws the Slider tick marks.
-void drawSliderTickMarks(QPainter* p, QRect const& tickmarksRect, QColor const& tickColor, const int min, const int max,
+QLEMENTINE_EXPORT void drawSliderTickMarks(QPainter* p, QRect const& tickmarksRect, QColor const& tickColor, const int min, const int max,
   const int interval, const int tickThickness, const int singleStep, const int pageStep);
 
 /// Draws the Dial tick marks.
-void drawDialTickMarks(QPainter* p, QRect const& tickmarksRect, QColor const& tickColor, const int min, const int max,
+QLEMENTINE_EXPORT void drawDialTickMarks(QPainter* p, QRect const& tickmarksRect, QColor const& tickColor, const int min, const int max,
   const int tickThickness, const int tickLength, const int singleStep, const int pageStep, const int minArcLength);
 
 /// Draws a Dial.
-void drawDial(QPainter* p, QRect const& rect, int min, int max, double value, QColor const& bgColor,
+QLEMENTINE_EXPORT void drawDial(QPainter* p, QRect const& rect, int min, int max, double value, QColor const& bgColor,
   QColor const& handleColor, QColor const& grooveColor, QColor const& valueColor, QColor const& markColor,
   const int grooveThickness, const int markLength, const int markThickness);
 
 /// Gets the path for a rounded tab. Specify negative radiuses if you want the tab to overlap its bounds.
-QPainterPath getTabPath(QRect const& rect, const RadiusesF& radiuses);
+QLEMENTINE_EXPORT QPainterPath getTabPath(QRect const& rect, const RadiusesF& radiuses);
 
 /// Draws a rounded tab. Specify negative radiuses if you want the tab to overlap its bounds.
-void drawTab(QPainter* p, QRect const& rect, const RadiusesF& radiuses, const QColor& bgColor, bool drawShadow = false,
+QLEMENTINE_EXPORT void drawTab(QPainter* p, QRect const& rect, const RadiusesF& radiuses, const QColor& bgColor, bool drawShadow = false,
   const QColor& shadowColor = Qt::black);
 
 /// Draws the shadow of a rounded tab.
-void drawTabShadow(QPainter* p, QRect const& rect, const RadiusesF& radius, const QColor& color);
+QLEMENTINE_EXPORT void drawTabShadow(QPainter* p, QRect const& rect, const RadiusesF& radius, const QColor& color);
 
 /// Draws a RadioButton indicator according to its checked state.
-void drawRadioButton(QPainter* p, const QRect& rect, QColor const& bgColor, const QColor& borderColor,
+QLEMENTINE_EXPORT void drawRadioButton(QPainter* p, const QRect& rect, QColor const& bgColor, const QColor& borderColor,
   QColor const& fgColor, const qreal borderWidth, qreal progress);
 
 /// Draws a CheckButton indicator according to its checked state.
-void drawCheckButton(QPainter* p, const QRect& rect, qreal radius, const QColor& bgColor, const QColor& borderColor,
+QLEMENTINE_EXPORT void drawCheckButton(QPainter* p, const QRect& rect, qreal radius, const QColor& bgColor, const QColor& borderColor,
   const QColor& fgColor, const qreal borderWidth, qreal progress, CheckState checkState);
 
 /// Draws a menu separator.
-void drawMenuSeparator(QPainter* p, const QRect& rect, QColor const& color, const int thickness);
+QLEMENTINE_EXPORT void drawMenuSeparator(QPainter* p, const QRect& rect, QColor const& color, const int thickness);
 
 /// Draws an elided text (with an ellipsis "…" at the end if necessary) inside a QRect.
 /// The difference with Qt's method is the ellipsis (Qt doesn't draw one and just cuts the text).
-void drawElidedMultiLineText(QPainter& p, const QRect& rect, const QString& text, const QPaintDevice* paintDevice);
+QLEMENTINE_EXPORT void drawElidedMultiLineText(QPainter& p, const QRect& rect, const QString& text, const QPaintDevice* paintDevice);
 
 /// Removes the trailing whitespaces at the end.
-QString removeTrailingWhitespaces(const QString& str);
+QLEMENTINE_EXPORT QString removeTrailingWhitespaces(const QString& str);
 
 /// Gives the text to draw when displaying a shortcut.
-QString displayedShortcutString(const QKeySequence& shortcut);
+QLEMENTINE_EXPORT QString displayedShortcutString(const QKeySequence& shortcut);
 
 /// Draws a keyboard shortcut.
-void drawShortcut(QPainter& p, const QKeySequence& shortcut, const QRect& rect, const Theme& theme, bool enabled,
+QLEMENTINE_EXPORT void drawShortcut(QPainter& p, const QKeySequence& shortcut, const QRect& rect, const Theme& theme, bool enabled,
   Qt::Alignment alignment = { Qt::AlignLeft | Qt::AlignVCenter });
 
 /// Gets the necessary size to display the whole shortcut.
-QSize shortcutSizeHint(const QKeySequence& shortcut, const Theme& theme);
+QLEMENTINE_EXPORT QSize shortcutSizeHint(const QKeySequence& shortcut, const Theme& theme);
 
 /// Gets the QPixmap that corresponds to the state and matches the best the desired iconSize.
 /// NB: the QPixmap may not be equal to iconSize: it can be smaller, but never larger.
-QPixmap getPixmap(
+QLEMENTINE_EXPORT QPixmap getPixmap(
   const QIcon& icon, const QSize& iconSize, const MouseState mouse, const CheckState checked, const QWidget* widget);
 
 /// Draws the icon to fill the rect. Returns the actual rect occupied by the pixmap (it can be smaller).
-QRect drawIcon(const QRect& rect, QPainter* p, const QIcon& icon, const MouseState mouse, const CheckState checked,
+QLEMENTINE_EXPORT QRect drawIcon(const QRect& rect, QPainter* p, const QIcon& icon, const MouseState mouse, const CheckState checked,
   const QWidget* widget, bool colorize = false, const QColor& color = {});
 
 /// Updates the QIcon with the QPixmap given by the function at the right size and for all states.
-void updateUncheckableButtonIconPixmap(
+QLEMENTINE_EXPORT void updateUncheckableButtonIconPixmap(
   QIcon& icon, const QSize& size, QlementineStyle const& style, const PixmapMakerFunc& func);
 
 /// Updates the QIcon that contains the check mark.
 /// NB: The unchecked version of the QIcon is empty on purpose (i.e. no check).
-void updateCheckIcon(QIcon& icon, QSize const& size, QlementineStyle const& style);
+QLEMENTINE_EXPORT void updateCheckIcon(QIcon& icon, QSize const& size, QlementineStyle const& style);
 
 /// Generates a pixmap for a specific state of QLineEdit's clear button.
-QPixmap makeClearButtonPixmap(QSize const& size, QColor const& color);
+QLEMENTINE_EXPORT QPixmap makeClearButtonPixmap(QSize const& size, QColor const& color);
 
 /// Generates a pixmap that contains a check mark.
-QPixmap makeCheckPixmap(QSize const& size, QColor const& color);
+QLEMENTINE_EXPORT QPixmap makeCheckPixmap(QSize const& size, QColor const& color);
 
 /// Generates a pixmap that contains a calendar.
-QPixmap makeCalendarPixmap(QSize const& size, QColor const& color);
+QLEMENTINE_EXPORT QPixmap makeCalendarPixmap(QSize const& size, QColor const& color);
 
 /// Generates a pixmap that contains a double right arrow.
-QPixmap makeDoubleArrowRightPixmap(QSize const& size, QColor const& color);
+QLEMENTINE_EXPORT QPixmap makeDoubleArrowRightPixmap(QSize const& size, QColor const& color);
 
 /// Generates a pixmap that contains a small double right arrow.
-QPixmap makeToolBarExtensionPixmap(QSize const& size, QColor const& color);
+QLEMENTINE_EXPORT QPixmap makeToolBarExtensionPixmap(QSize const& size, QColor const& color);
 
 /// Generates a pixmap that contains a left arrow.
-QPixmap makeArrowLeftPixmap(QSize const& size, QColor const& color);
+QLEMENTINE_EXPORT QPixmap makeArrowLeftPixmap(QSize const& size, QColor const& color);
 
 /// Generates a pixmap that contains a right arrow.
-QPixmap makeArrowRightPixmap(QSize const& size, QColor const& color);
+QLEMENTINE_EXPORT QPixmap makeArrowRightPixmap(QSize const& size, QColor const& color);
 
-QPixmap makeMessageBoxWarningPixmap(QSize const& size, QColor const& bgColor, QColor const& fgColor);
-QPixmap makeMessageBoxCriticalPixmap(QSize const& size, QColor const& bgColor, QColor const& fgColor);
-QPixmap makeMessageBoxQuestionPixmap(QSize const& size, QColor const& bgColor, QColor const& fgColor);
-QPixmap makeMessageBoxInformationPixmap(QSize const& size, QColor const& bgColor, QColor const& fgColor);
+QLEMENTINE_EXPORT QPixmap makeMessageBoxWarningPixmap(QSize const& size, QColor const& bgColor, QColor const& fgColor);
+QLEMENTINE_EXPORT QPixmap makeMessageBoxCriticalPixmap(QSize const& size, QColor const& bgColor, QColor const& fgColor);
+QLEMENTINE_EXPORT QPixmap makeMessageBoxQuestionPixmap(QSize const& size, QColor const& bgColor, QColor const& fgColor);
+QLEMENTINE_EXPORT QPixmap makeMessageBoxInformationPixmap(QSize const& size, QColor const& bgColor, QColor const& fgColor);
 
-void updateMessageBoxWarningIcon(QIcon& icon, QSize const& size, Theme const& theme);
-void updateMessageBoxCriticalIcon(QIcon& icon, QSize const& size, Theme const& theme);
-void updateMessageBoxQuestionIcon(QIcon& icon, QSize const& size, Theme const& theme);
-void updateMessageBoxInformationIcon(QIcon& icon, QSize const& size, Theme const& theme);
+QLEMENTINE_EXPORT void updateMessageBoxWarningIcon(QIcon& icon, QSize const& size, Theme const& theme);
+QLEMENTINE_EXPORT void updateMessageBoxCriticalIcon(QIcon& icon, QSize const& size, Theme const& theme);
+QLEMENTINE_EXPORT void updateMessageBoxQuestionIcon(QIcon& icon, QSize const& size, Theme const& theme);
+QLEMENTINE_EXPORT void updateMessageBoxInformationIcon(QIcon& icon, QSize const& size, Theme const& theme);
 } // namespace oclero::qlementine

--- a/lib/include/oclero/qlementine/utils/StateUtils.hpp
+++ b/lib/include/oclero/qlementine/utils/StateUtils.hpp
@@ -3,41 +3,42 @@
 
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
 #include <oclero/qlementine/style/Theme.hpp>
 
 #include <QStyle>
 #include <QStyleOption>
 
 namespace oclero::qlementine {
-MouseState getMouseState(QStyle::State const& state);
-MouseState getMouseState(bool const pressed, bool const hovered, bool const enabled);
-MouseState getToolButtonMouseState(QStyle::State const& state);
-MouseState getMenuItemMouseState(QStyle::State const& state);
-MouseState getComboBoxItemMouseState(QStyle::State const& state);
-MouseState getTabItemMouseState(QStyle::State const& state, const bool tabIsHovered);
-ColorRole getColorRole(QStyle::State const& state, bool const isDefault);
-ColorRole getColorRole(bool checked, bool const isDefault);
-ColorRole getColorRole(CheckState const checked);
-MouseState getSliderHandleState(QStyle::State const& state, QStyle::SubControls const activeSubControls);
-MouseState getScrollBarHandleState(QStyle::State const& state, QStyle::SubControls const activeSubControls);
-FocusState getFocusState(QStyle::State const& state);
-FocusState getFocusState(bool focused);
-CheckState getCheckState(QStyle::State const& state);
-CheckState getCheckState(Qt::CheckState const& state);
-CheckState getCheckState(bool checked);
-ActiveState getActiveState(QStyle::State const& state);
-SelectionState getSelectionState(QStyle::State const& state);
-AlternateState getAlternateState(QStyleOptionViewItem::ViewItemFeatures const& state);
-QStyle::State getState(const bool enabled, const bool hover, const bool pressed);
-QIcon::Mode getIconMode(MouseState const mouse);
-QIcon::State getIconState(CheckState const checked);
-QPalette::ColorGroup getPaletteColorGroup(QStyle::State const& state);
-QPalette::ColorGroup getPaletteColorGroup(MouseState const mouse);
+QLEMENTINE_EXPORT MouseState getMouseState(QStyle::State const& state);
+QLEMENTINE_EXPORT MouseState getMouseState(bool const pressed, bool const hovered, bool const enabled);
+QLEMENTINE_EXPORT MouseState getToolButtonMouseState(QStyle::State const& state);
+QLEMENTINE_EXPORT MouseState getMenuItemMouseState(QStyle::State const& state);
+QLEMENTINE_EXPORT MouseState getComboBoxItemMouseState(QStyle::State const& state);
+QLEMENTINE_EXPORT MouseState getTabItemMouseState(QStyle::State const& state, const bool tabIsHovered);
+QLEMENTINE_EXPORT ColorRole getColorRole(QStyle::State const& state, bool const isDefault);
+QLEMENTINE_EXPORT ColorRole getColorRole(bool checked, bool const isDefault);
+QLEMENTINE_EXPORT ColorRole getColorRole(CheckState const checked);
+QLEMENTINE_EXPORT MouseState getSliderHandleState(QStyle::State const& state, QStyle::SubControls const activeSubControls);
+QLEMENTINE_EXPORT MouseState getScrollBarHandleState(QStyle::State const& state, QStyle::SubControls const activeSubControls);
+QLEMENTINE_EXPORT FocusState getFocusState(QStyle::State const& state);
+QLEMENTINE_EXPORT FocusState getFocusState(bool focused);
+QLEMENTINE_EXPORT CheckState getCheckState(QStyle::State const& state);
+QLEMENTINE_EXPORT CheckState getCheckState(Qt::CheckState const& state);
+QLEMENTINE_EXPORT CheckState getCheckState(bool checked);
+QLEMENTINE_EXPORT ActiveState getActiveState(QStyle::State const& state);
+QLEMENTINE_EXPORT SelectionState getSelectionState(QStyle::State const& state);
+QLEMENTINE_EXPORT AlternateState getAlternateState(QStyleOptionViewItem::ViewItemFeatures const& state);
+QLEMENTINE_EXPORT QStyle::State getState(const bool enabled, const bool hover, const bool pressed);
+QLEMENTINE_EXPORT QIcon::Mode getIconMode(MouseState const mouse);
+QLEMENTINE_EXPORT QIcon::State getIconState(CheckState const checked);
+QLEMENTINE_EXPORT QPalette::ColorGroup getPaletteColorGroup(QStyle::State const& state);
+QLEMENTINE_EXPORT QPalette::ColorGroup getPaletteColorGroup(MouseState const mouse);
 
-QString mouseStateToString(MouseState const state);
-QString focusStateToString(FocusState const state);
-QString activeStateToString(ActiveState const state);
-QString selectionStateToString(SelectionState const state);
-QString checkStateToString(CheckState const state);
-QString printState(QStyle::State const& state);
+QLEMENTINE_EXPORT QString mouseStateToString(MouseState const state);
+QLEMENTINE_EXPORT QString focusStateToString(FocusState const state);
+QLEMENTINE_EXPORT QString activeStateToString(ActiveState const state);
+QLEMENTINE_EXPORT QString selectionStateToString(SelectionState const state);
+QLEMENTINE_EXPORT QString checkStateToString(CheckState const state);
+QLEMENTINE_EXPORT QString printState(QStyle::State const& state);
 } // namespace oclero::qlementine

--- a/lib/include/oclero/qlementine/utils/StyleUtils.hpp
+++ b/lib/include/oclero/qlementine/utils/StyleUtils.hpp
@@ -3,39 +3,41 @@
 
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
+
 #include <QWidget>
 #include <QStyleOption>
 
 namespace oclero::qlementine {
 /// Hover events (enter/leave events) are disabled by default on widgets.
 /// However, some widgets need them.
-bool shouldHaveHoverEvents(const QWidget* w);
+QLEMENTINE_EXPORT bool shouldHaveHoverEvents(const QWidget* w);
 
 /// Mouse tracking events (mouse moved events) are disabled by default on widgets.
 /// However, some widgets need them.
-bool shouldHaveMouseTracking(const QWidget* w);
+QLEMENTINE_EXPORT bool shouldHaveMouseTracking(const QWidget* w);
 
 /// Should the widget text be displayed in bold.
-bool shouldHaveBoldFont(const QWidget* w);
+QLEMENTINE_EXPORT bool shouldHaveBoldFont(const QWidget* w);
 
 /// Focus border outside the widget.
-bool shouldHaveExternalFocusFrame(const QWidget* w);
+QLEMENTINE_EXPORT bool shouldHaveExternalFocusFrame(const QWidget* w);
 
 /// Should the widget be focusable only with Tab.
-bool shouldHaveTabFocus(const QWidget* w);
+QLEMENTINE_EXPORT bool shouldHaveTabFocus(const QWidget* w);
 
 /// Should we prevent the widget to resize vertically.
-bool shouldNotBeVerticallyCompressed(const QWidget* w);
+QLEMENTINE_EXPORT bool shouldNotBeVerticallyCompressed(const QWidget* w);
 
 /// Horizontal paddings (left, right) are different according to the content of the widget.
-std::tuple<int, int> getHPaddings(const bool hasIcon, const bool hasText, const bool hasIndicator, const int padding);
+QLEMENTINE_EXPORT std::tuple<int, int> getHPaddings(const bool hasIcon, const bool hasText, const bool hasIndicator, const int padding);
 
 /// Should the widget not receive wheel events when not focused.
-bool shouldNotHaveWheelEvents(const QWidget* w);
+QLEMENTINE_EXPORT bool shouldNotHaveWheelEvents(const QWidget* w);
 
 /// Gets the tab index from the QStyleOption (if v4 or superior), or from the tab position in the QTabBar.
-int getTabIndex(const QStyleOptionTab* optTab, const QWidget* parentWidget);
+QLEMENTINE_EXPORT int getTabIndex(const QStyleOptionTab* optTab, const QWidget* parentWidget);
 
 /// Gets the tab count.
-int getTabCount(const QWidget* parentWidget);
+QLEMENTINE_EXPORT int getTabCount(const QWidget* parentWidget);
 } // namespace oclero::qlementine

--- a/lib/include/oclero/qlementine/utils/WidgetUtils.hpp
+++ b/lib/include/oclero/qlementine/utils/WidgetUtils.hpp
@@ -3,21 +3,23 @@
 
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
+
 #include <QWidget>
 #include <QScreen>
 #include <QGuiApplication>
 
 namespace oclero::qlementine {
-QWidget* makeVerticalLine(QWidget* parentWidget, int maxHeight = -1);
-QWidget* makeHorizontalLine(QWidget* parentWidget, int maxWidth = -1);
+QLEMENTINE_EXPORT QWidget* makeVerticalLine(QWidget* parentWidget, int maxHeight = -1);
+QLEMENTINE_EXPORT QWidget* makeHorizontalLine(QWidget* parentWidget, int maxWidth = -1);
 
-void centerWidget(QWidget* widget, QWidget* host = nullptr);
+QLEMENTINE_EXPORT void centerWidget(QWidget* widget, QWidget* host = nullptr);
 
-qreal getDpi(const QWidget* widget);
+QLEMENTINE_EXPORT qreal getDpi(const QWidget* widget);
 
-QWindow* getWindow(const QWidget* widget);
+QLEMENTINE_EXPORT QWindow* getWindow(const QWidget* widget);
 
-void clearFocus(QWidget* widget, bool recursive);
+QLEMENTINE_EXPORT void clearFocus(QWidget* widget, bool recursive);
 
 template<class T>
 T* findFirstParentOfType(QWidget* child) {

--- a/lib/include/oclero/qlementine/widgets/AboutDialog.hpp
+++ b/lib/include/oclero/qlementine/widgets/AboutDialog.hpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
+
 #include <QDialog>
 
 class QLabel;
@@ -14,7 +16,7 @@ class Label;
 /// It includes the application icon, description, website link, license information,
 /// copyright notice, and social media links.
 /// It will automatically use the application's icon and name if not set explicitly.
-class AboutDialog : public QDialog {
+class QLEMENTINE_EXPORT AboutDialog : public QDialog {
   Q_OBJECT
 
 public:

--- a/lib/include/oclero/qlementine/widgets/AbstractItemListWidget.hpp
+++ b/lib/include/oclero/qlementine/widgets/AbstractItemListWidget.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
 #include <oclero/qlementine/style/Theme.hpp>
 #include <oclero/qlementine/style/QlementineStyleOption.hpp>
 
@@ -18,7 +19,7 @@ namespace oclero::qlementine {
 class RoundedFocusFrame;
 
 /// A class to factorize common behavior between widgets such as tab bars.
-class AbstractItemListWidget : public QWidget {
+class QLEMENTINE_EXPORT AbstractItemListWidget : public QWidget {
   Q_OBJECT
 
   Q_PROPERTY(int currentIndex READ currentIndex WRITE setCurrentIndex NOTIFY currentIndexChanged)

--- a/lib/include/oclero/qlementine/widgets/ColorButton.hpp
+++ b/lib/include/oclero/qlementine/widgets/ColorButton.hpp
@@ -6,10 +6,11 @@
 #include <QAbstractButton>
 #include <QColor>
 
+#include <oclero/qlementine/qlementine_export.h>
 #include <oclero/qlementine/Common.hpp>
 
 namespace oclero::qlementine {
-class ColorButton : public QAbstractButton {
+class QLEMENTINE_EXPORT ColorButton : public QAbstractButton {
   Q_OBJECT
 
   Q_PROPERTY(QColor color READ color WRITE setColor NOTIFY colorChanged)

--- a/lib/include/oclero/qlementine/widgets/ColorEditor.hpp
+++ b/lib/include/oclero/qlementine/widgets/ColorEditor.hpp
@@ -6,13 +6,14 @@
 #include <QWidget>
 #include <QColor>
 
+#include <oclero/qlementine/qlementine_export.h>
 #include <oclero/qlementine/Common.hpp>
 
 namespace oclero::qlementine {
 class ColorButton;
 class LineEdit;
 
-class ColorEditor : public QWidget {
+class QLEMENTINE_EXPORT ColorEditor : public QWidget {
   Q_OBJECT
 
   Q_PROPERTY(QColor color READ color WRITE setColor NOTIFY colorChanged)

--- a/lib/include/oclero/qlementine/widgets/CommandLinkButton.hpp
+++ b/lib/include/oclero/qlementine/widgets/CommandLinkButton.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
+
 #include <QCommandLinkButton>
 
 namespace oclero::qlementine {
@@ -10,7 +12,7 @@ class QStyleOptionCommandLinkButton;
 
 /// A QCommandLinkButton that just doesn't force its size to Windows Vista's
 /// system-default CommandLinkButtton size. It actually lets content decide.
-class CommandLinkButton : public QCommandLinkButton {
+class QLEMENTINE_EXPORT CommandLinkButton : public QCommandLinkButton {
 public:
   explicit CommandLinkButton(QWidget* parent = nullptr);
   explicit CommandLinkButton(const QString& text, QWidget* parent = nullptr);

--- a/lib/include/oclero/qlementine/widgets/Expander.hpp
+++ b/lib/include/oclero/qlementine/widgets/Expander.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
+
 #include <QWidget>
 #include <QPointer>
 #include <QVariantAnimation>
@@ -10,7 +12,7 @@
 namespace oclero::qlementine {
 /// A QWidget that allows to expand vertically or horizontally,
 /// revealing or hiding its content with an animation.
-class Expander : public QWidget {
+class QLEMENTINE_EXPORT Expander : public QWidget {
   Q_OBJECT
 
   Q_PROPERTY(bool expanded READ expanded WRITE setExpanded NOTIFY expandedChanged)

--- a/lib/include/oclero/qlementine/widgets/IconWidget.hpp
+++ b/lib/include/oclero/qlementine/widgets/IconWidget.hpp
@@ -3,12 +3,14 @@
 
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
+
 #include <QWidget>
 #include <QIcon>
 
 namespace oclero::qlementine {
 /// A QWidget that displays a QIcon and paints the correct image according to its state.
-class IconWidget : public QWidget {
+class QLEMENTINE_EXPORT IconWidget : public QWidget {
   Q_OBJECT
 
   Q_PROPERTY(QIcon icon READ icon WRITE setIcon NOTIFY iconChanged)

--- a/lib/include/oclero/qlementine/widgets/Label.hpp
+++ b/lib/include/oclero/qlementine/widgets/Label.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
 #include <oclero/qlementine/Common.hpp>
 
 #include <QLabel>
@@ -10,7 +11,7 @@
 namespace oclero::qlementine {
 /// A QLabel that handles automatic styling for different text roles (titles, normal text, ect.)
 /// like h1,h2,p in HTML.
-class Label : public QLabel {
+class QLEMENTINE_EXPORT Label : public QLabel {
   Q_OBJECT
 
   Q_PROPERTY(oclero::qlementine::TextRole role READ role WRITE setRole NOTIFY roleChanged)

--- a/lib/include/oclero/qlementine/widgets/LineEdit.hpp
+++ b/lib/include/oclero/qlementine/widgets/LineEdit.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
 #include <oclero/qlementine/style/Theme.hpp>
 #include <oclero/qlementine/Common.hpp>
 
@@ -12,7 +13,7 @@
 
 namespace oclero::qlementine {
 /// A QLineEdit that draws a search icon
-class LineEdit : public QLineEdit {
+class QLEMENTINE_EXPORT LineEdit : public QLineEdit {
   Q_OBJECT
 
   Q_PROPERTY(QIcon icon READ icon WRITE setIcon NOTIFY iconChanged)

--- a/lib/include/oclero/qlementine/widgets/LoadingSpinner.hpp
+++ b/lib/include/oclero/qlementine/widgets/LoadingSpinner.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
 #include <oclero/qlementine/style/Theme.hpp>
 #include <oclero/qlementine/Common.hpp>
 
@@ -12,7 +13,7 @@
 
 namespace oclero::qlementine {
 /// An animated loading spinner.
-class LoadingSpinner : public QWidget {
+class QLEMENTINE_EXPORT LoadingSpinner : public QWidget {
   Q_OBJECT
 
   Q_PROPERTY(bool spinning READ spinning WRITE setSpinning NOTIFY spinningChanged)

--- a/lib/include/oclero/qlementine/widgets/Menu.hpp
+++ b/lib/include/oclero/qlementine/widgets/Menu.hpp
@@ -5,11 +5,13 @@
 
 #include <functional>
 
+#include <oclero/qlementine/qlementine_export.h>
+
 #include <QMenu>
 #include <QAction>
 
 namespace oclero::qlementine {
-class Menu : public QMenu {
+class QLEMENTINE_EXPORT Menu : public QMenu {
   Q_OBJECT
 
 public:

--- a/lib/include/oclero/qlementine/widgets/NavigationBar.hpp
+++ b/lib/include/oclero/qlementine/widgets/NavigationBar.hpp
@@ -3,11 +3,12 @@
 
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
 #include <oclero/qlementine/widgets/AbstractItemListWidget.hpp>
 
 namespace oclero::qlementine {
 /// A TabBar with tabs like on Android.
-class NavigationBar : public AbstractItemListWidget {
+class QLEMENTINE_EXPORT NavigationBar : public AbstractItemListWidget {
 public:
   using AbstractItemListWidget::AbstractItemListWidget;
 

--- a/lib/include/oclero/qlementine/widgets/NotificationBadge.hpp
+++ b/lib/include/oclero/qlementine/widgets/NotificationBadge.hpp
@@ -3,13 +3,15 @@
 
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
+
 #include <QWidget>
 #include <QPointer>
 #include <QMargins>
 
 namespace oclero::qlementine {
 /// A small badge to display a notification (with or without text) on another widget.
-class NotificationBadge : public QWidget {
+class QLEMENTINE_EXPORT NotificationBadge : public QWidget {
   Q_OBJECT
 
   Q_PROPERTY(QString text READ text WRITE setText NOTIFY textChanged)

--- a/lib/include/oclero/qlementine/widgets/PlainTextEdit.hpp
+++ b/lib/include/oclero/qlementine/widgets/PlainTextEdit.hpp
@@ -3,13 +3,14 @@
 
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
 #include <oclero/qlementine/Common.hpp>
 
 #include <QPlainTextEdit>
 
 namespace oclero::qlementine {
 /// An improved QPlainTextEdit.
-class PlainTextEdit : public QPlainTextEdit {
+class QLEMENTINE_EXPORT PlainTextEdit : public QPlainTextEdit {
   Q_OBJECT
 
   Q_PROPERTY(Status status READ status WRITE setStatus NOTIFY statusChanged)

--- a/lib/include/oclero/qlementine/widgets/Popover.hpp
+++ b/lib/include/oclero/qlementine/widgets/Popover.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
+
 #include <QBitmap>
 #include <QList>
 #include <QPointer>
@@ -15,7 +17,7 @@
 
 namespace oclero::qlementine {
 // A MacOS-like popover.
-class Popover : public QWidget {
+class QLEMENTINE_EXPORT Popover : public QWidget {
   Q_OBJECT
 
   Q_PROPERTY(bool manualPositioning READ manualPositioning WRITE setManualPositioning NOTIFY manualPositioningChanged)

--- a/lib/include/oclero/qlementine/widgets/PopoverButton.hpp
+++ b/lib/include/oclero/qlementine/widgets/PopoverButton.hpp
@@ -3,13 +3,15 @@
 
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
+
 #include <QPushButton>
 
 namespace oclero::qlementine {
 class Popover;
 
 /// A Button that looks like a ComboBox but opens a Popover.
-class PopoverButton : public QPushButton {
+class QLEMENTINE_EXPORT PopoverButton : public QPushButton {
   Q_OBJECT
 
 public:

--- a/lib/include/oclero/qlementine/widgets/RoundedFocusFrame.hpp
+++ b/lib/include/oclero/qlementine/widgets/RoundedFocusFrame.hpp
@@ -3,13 +3,14 @@
 
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
 #include <oclero/qlementine/utils/RadiusesF.hpp>
 
 #include <QFocusFrame>
 
 namespace oclero::qlementine {
 /// A rounded QFocusFrame.
-class RoundedFocusFrame : public QFocusFrame {
+class QLEMENTINE_EXPORT RoundedFocusFrame : public QFocusFrame {
   Q_OBJECT
 
   Q_PROPERTY(RadiusesF radiuses READ radiuses WRITE setRadiuses NOTIFY radiusesChanged)

--- a/lib/include/oclero/qlementine/widgets/SegmentedControl.hpp
+++ b/lib/include/oclero/qlementine/widgets/SegmentedControl.hpp
@@ -3,11 +3,12 @@
 
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
 #include <oclero/qlementine/widgets/AbstractItemListWidget.hpp>
 
 namespace oclero::qlementine {
 /// A SegmentedControl like on MacOS.
-class SegmentedControl : public AbstractItemListWidget {
+class QLEMENTINE_EXPORT SegmentedControl : public AbstractItemListWidget {
 public:
   using AbstractItemListWidget::AbstractItemListWidget;
 

--- a/lib/include/oclero/qlementine/widgets/StatusBadgeWidget.hpp
+++ b/lib/include/oclero/qlementine/widgets/StatusBadgeWidget.hpp
@@ -3,13 +3,15 @@
 
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
+
 #include <QWidget>
 
 #include <oclero/qlementine/utils/BadgeUtils.hpp>
 
 namespace oclero::qlementine {
 /// A QWidget that displays a badge indicating Status (Error, etc.).
-class StatusBadgeWidget : public QWidget {
+class QLEMENTINE_EXPORT StatusBadgeWidget : public QWidget {
   Q_OBJECT
 
 public:

--- a/lib/include/oclero/qlementine/widgets/Switch.hpp
+++ b/lib/include/oclero/qlementine/widgets/Switch.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <oclero/qlementine/qlementine_export.h>
 #include <oclero/qlementine/widgets/RoundedFocusFrame.hpp>
 
 #include <QAbstractButton>
@@ -12,7 +13,7 @@ namespace oclero::qlementine {
 class QStyleOptionFocusRoundedRect;
 
 /// A switch toggle button like on iOS and Android.
-class Switch : public QAbstractButton {
+class QLEMENTINE_EXPORT Switch : public QAbstractButton {
   Q_OBJECT
 
   Q_PROPERTY(bool tristate READ isTristate WRITE setTristate NOTIFY tristateChanged)


### PR DESCRIPTION
Downstream distributions prefer to package dependencies like this as a system library so that it only needs to be updated in one place if a vulnerability is discovered (etc).

An example of this being needed in the real world is Gentoo, where we're currently shipping the first patch in this series, which is required for our builds of Solarus:

https://gitlab.com/solarus-games/solarus/-/merge_requests/1679

This should be all that's required for cross-platform shared library support, if that's how people want to package things. It shouldn't have any impact on existing static library consumers.

At a high level, the biggest changes (aside from building a .so/dll) are adding pkgconfig support (in case anyone wants to consume with meson or a non-cmake build system), and providing appropriate CMake bits and pieces to enable a system library to be found that way.

Docs have also been updated to provide examples of consuming Solarus as a shared library in various build systems (CMake and Meson).