### PR TITLE
feat: support dynamic Theme scaling

### DIFF
--- a/lib/include/oclero/qlementine/style/QlementineStyle.hpp
+++ b/lib/include/oclero/qlementine/style/QlementineStyle.hpp
@@ -21,7 +21,7 @@ class QlementineStyle : public QCommonStyle {
   Q_OBJECT
 
   Q_PROPERTY(bool animationsEnabled READ animationsEnabled WRITE setAnimationsEnabled NOTIFY animationsEnabledChanged)
-  Q_PROPERTY(double zoomFactor READ zoomFactor WRITE setZoomFactor NOTIFY zoomFactorChanged)
+  Q_PROPERTY(double scaleFactor READ scaleFactor WRITE setScaleFactor NOTIFY scaleFactorChanged)
 
 public:
   enum class StandardPixmapExt {
@@ -60,9 +60,9 @@ public:
   void setAnimationsEnabled(bool enabled);
   Q_SIGNAL void animationsEnabledChanged();
 
-  double zoomFactor() const;
-  void setZoomFactor(double factor);
-  Q_SIGNAL void zoomFactorChanged();
+  double scaleFactor() const;
+  void setScaleFactor(double factor);
+  Q_SIGNAL void scaleFactorChanged();
 
   virtual void triggerCompleteRepaint();
 

--- a/lib/include/oclero/qlementine/style/QlementineStyle.hpp
+++ b/lib/include/oclero/qlementine/style/QlementineStyle.hpp
@@ -21,6 +21,7 @@ class QlementineStyle : public QCommonStyle {
   Q_OBJECT
 
   Q_PROPERTY(bool animationsEnabled READ animationsEnabled WRITE setAnimationsEnabled NOTIFY animationsEnabledChanged)
+  Q_PROPERTY(double zoomFactor READ zoomFactor WRITE setZoomFactor NOTIFY zoomFactorChanged)
 
 public:
   enum class StandardPixmapExt {
@@ -58,6 +59,10 @@ public:
   bool animationsEnabled() const;
   void setAnimationsEnabled(bool enabled);
   Q_SIGNAL void animationsEnabledChanged();
+
+  double zoomFactor() const;
+  void setZoomFactor(double factor);
+  Q_SIGNAL void zoomFactorChanged();
 
   virtual void triggerCompleteRepaint();
 

--- a/lib/include/oclero/qlementine/style/Theme.hpp
+++ b/lib/include/oclero/qlementine/style/Theme.hpp
@@ -202,6 +202,9 @@ public: // Values.
 public:
   QJsonDocument toJson() const;
 
+  /// Returns a copy with all dimension fields scaled by the given factor.
+  Theme scaled(double factor) const;
+
 private:
   void initializeFonts();
   void initializePalette();

--- a/lib/src/style/QlementineStyle.cpp
+++ b/lib/src/style/QlementineStyle.cpp
@@ -247,7 +247,7 @@ struct QlementineStyleImpl {
   QlementineStyle& owner;
   Theme theme{};
   Theme baseTheme{};
-  double zoomFactor{ 1.0 };
+  double scaleFactor{ 1.0 };
   std::unique_ptr<QFontMetrics> fontMetricsBold{ nullptr };
   WidgetAnimationManager animations;
   std::unordered_map<QStyle::StandardPixmap, QIcon> standardIconCache;
@@ -276,7 +276,7 @@ Theme const& QlementineStyle::theme() const {
 void QlementineStyle::setTheme(Theme const& theme) {
   if (_impl->baseTheme != theme) {
     _impl->baseTheme = theme;
-    _impl->theme = theme.scaled(_impl->zoomFactor);
+    _impl->theme = theme.scaled(_impl->scaleFactor);
     Q_EMIT themeChanged();
 
     triggerCompleteRepaint();
@@ -302,17 +302,17 @@ void QlementineStyle::setAnimationsEnabled(bool enabled) {
   }
 }
 
-double QlementineStyle::zoomFactor() const {
-  return _impl->zoomFactor;
+double QlementineStyle::scaleFactor() const {
+  return _impl->scaleFactor;
 }
 
-void QlementineStyle::setZoomFactor(double factor) {
+void QlementineStyle::setScaleFactor(double factor) {
   factor = qBound(0.5, factor, 4.0);
-  if (qFuzzyCompare(_impl->zoomFactor, factor))
+  if (qFuzzyCompare(_impl->scaleFactor, factor))
     return;
-  _impl->zoomFactor = factor;
+  _impl->scaleFactor = factor;
   _impl->theme = _impl->baseTheme.scaled(factor);
-  Q_EMIT zoomFactorChanged();
+  Q_EMIT scaleFactorChanged();
   triggerCompleteRepaint();
 }
 

--- a/lib/src/style/QlementineStyle.cpp
+++ b/lib/src/style/QlementineStyle.cpp
@@ -246,6 +246,8 @@ struct QlementineStyleImpl {
 
   QlementineStyle& owner;
   Theme theme{};
+  Theme baseTheme{};
+  double zoomFactor{ 1.0 };
   std::unique_ptr<QFontMetrics> fontMetricsBold{ nullptr };
   WidgetAnimationManager animations;
   std::unordered_map<QStyle::StandardPixmap, QIcon> standardIconCache;
@@ -272,8 +274,9 @@ Theme const& QlementineStyle::theme() const {
 }
 
 void QlementineStyle::setTheme(Theme const& theme) {
-  if (_impl->theme != theme) {
-    _impl->theme = theme;
+  if (_impl->baseTheme != theme) {
+    _impl->baseTheme = theme;
+    _impl->theme = theme.scaled(_impl->zoomFactor);
     Q_EMIT themeChanged();
 
     triggerCompleteRepaint();
@@ -297,6 +300,20 @@ void QlementineStyle::setAnimationsEnabled(bool enabled) {
     Q_EMIT animationsEnabledChanged();
     triggerCompleteRepaint();
   }
+}
+
+double QlementineStyle::zoomFactor() const {
+  return _impl->zoomFactor;
+}
+
+void QlementineStyle::setZoomFactor(double factor) {
+  factor = qBound(0.5, factor, 4.0);
+  if (qFuzzyCompare(_impl->zoomFactor, factor))
+    return;
+  _impl->zoomFactor = factor;
+  _impl->theme = _impl->baseTheme.scaled(factor);
+  Q_EMIT zoomFactorChanged();
+  triggerCompleteRepaint();
 }
 
 void QlementineStyle::triggerCompleteRepaint() {

--- a/lib/src/style/Theme.cpp
+++ b/lib/src/style/Theme.cpp
@@ -826,12 +826,12 @@ Theme Theme::scaled(double factor) const {
   // ScrollBar.
   t.scrollBarThicknessFull = scaleInt(scrollBarThicknessFull);
   t.scrollBarThicknessSmall = scaleInt(scrollBarThicknessSmall);
-  t.scrollBarMargin = static_cast<int>(std::round(scrollBarMargin * factor));
+  t.scrollBarMargin = scaleInt(scrollBarMargin);
 
   // TabBar.
   t.tabBarPaddingTop = scaleInt(tabBarPaddingTop);
-  t.tabBarTabMaxWidth = tabBarTabMaxWidth > 0 ? scaleInt(tabBarTabMaxWidth) : 0;
-  t.tabBarTabMinWidth = tabBarTabMinWidth > 0 ? scaleInt(tabBarTabMinWidth) : 0;
+  t.tabBarTabMaxWidth = scaleInt(tabBarTabMaxWidth);
+  t.tabBarTabMinWidth = scaleInt(tabBarTabMinWidth);
 
   // Regenerate fonts from the scaled font sizes.
   t.initializeFonts();

--- a/lib/src/style/Theme.cpp
+++ b/lib/src/style/Theme.cpp
@@ -14,6 +14,8 @@
 #include <QVector>
 #include <QGuiApplication>
 
+#include <algorithm>
+#include <cmath>
 #include <optional>
 
 namespace oclero::qlementine {
@@ -752,6 +754,89 @@ bool Theme::operator==(const Theme& other) const {
 
 bool Theme::operator!=(const Theme& other) const {
   return !(*this == other);
+}
+
+Theme Theme::scaled(double factor) const {
+  if (qFuzzyCompare(factor, 1.0))
+    return *this;
+
+  Theme t = *this;
+
+  auto scaleInt = [factor](int v) -> int {
+    return v <= 0 ? v : std::max(1, static_cast<int>(std::round(v * factor)));
+  };
+  auto scaleDouble = [factor](double v) -> double {
+    return v <= 0.0 ? v : v * factor;
+  };
+  auto scaleSize = [&scaleInt](const QSize& s) -> QSize {
+    return { scaleInt(s.width()), scaleInt(s.height()) };
+  };
+
+  // Font sizes.
+  t.fontSize = scaleInt(fontSize);
+  t.fontSizeMonospace = scaleInt(fontSizeMonospace);
+  t.fontSizeH1 = scaleInt(fontSizeH1);
+  t.fontSizeH2 = scaleInt(fontSizeH2);
+  t.fontSizeH3 = scaleInt(fontSizeH3);
+  t.fontSizeH4 = scaleInt(fontSizeH4);
+  t.fontSizeH5 = scaleInt(fontSizeH5);
+  t.fontSizeS1 = scaleInt(fontSizeS1);
+
+  // Radii.
+  t.borderRadius = scaleDouble(borderRadius);
+  t.checkBoxBorderRadius = scaleDouble(checkBoxBorderRadius);
+  t.menuItemBorderRadius = scaleDouble(menuItemBorderRadius);
+  t.menuBarItemBorderRadius = scaleDouble(menuBarItemBorderRadius);
+
+  // Borders.
+  t.borderWidth = scaleInt(borderWidth);
+  t.focusBorderWidth = scaleInt(focusBorderWidth);
+
+  // Control sizes.
+  t.controlHeightLarge = scaleInt(controlHeightLarge);
+  t.controlHeightMedium = scaleInt(controlHeightMedium);
+  t.controlHeightSmall = scaleInt(controlHeightSmall);
+  t.controlDefaultWidth = scaleInt(controlDefaultWidth);
+
+  // Icons.
+  t.iconSize = scaleSize(iconSize);
+  t.iconSizeMedium = scaleSize(iconSizeMedium);
+  t.iconSizeLarge = scaleSize(iconSizeLarge);
+  t.iconSizeExtraSmall = scaleSize(iconSizeExtraSmall);
+
+  // Slider.
+  t.sliderTickSize = scaleInt(sliderTickSize);
+  t.sliderTickSpacing = scaleInt(sliderTickSpacing);
+  t.sliderTickThickness = scaleInt(sliderTickThickness);
+  t.sliderGrooveHeight = scaleInt(sliderGrooveHeight);
+
+  // ProgressBar.
+  t.progressBarGrooveHeight = scaleInt(progressBarGrooveHeight);
+
+  // Dial.
+  t.dialMarkLength = scaleInt(dialMarkLength);
+  t.dialMarkThickness = scaleInt(dialMarkThickness);
+  t.dialTickLength = scaleInt(dialTickLength);
+  t.dialTickSpacing = scaleInt(dialTickSpacing);
+  t.dialGrooveThickness = scaleInt(dialGrooveThickness);
+
+  // Spacing.
+  t.spacing = scaleInt(spacing);
+
+  // ScrollBar.
+  t.scrollBarThicknessFull = scaleInt(scrollBarThicknessFull);
+  t.scrollBarThicknessSmall = scaleInt(scrollBarThicknessSmall);
+  t.scrollBarMargin = static_cast<int>(std::round(scrollBarMargin * factor));
+
+  // TabBar.
+  t.tabBarPaddingTop = scaleInt(tabBarPaddingTop);
+  t.tabBarTabMaxWidth = tabBarTabMaxWidth > 0 ? scaleInt(tabBarTabMaxWidth) : 0;
+  t.tabBarTabMinWidth = tabBarTabMinWidth > 0 ? scaleInt(tabBarTabMinWidth) : 0;
+
+  // Regenerate fonts from the scaled font sizes.
+  t.initializeFonts();
+
+  return t;
 }
 
 } // namespace oclero::qlementine


### PR DESCRIPTION
Qt's built-in scaling (`QT_SCALE_FACTOR`) only works at launch time. For applications that want to offer runtime UI zoom (e.g. `Cmd+=/Cmd+-` like VS Code), there's currently no way to do this.  Before discovering Qlementine, I had a similar parametrized QStyle object, but it supported theme-based scaling.  in Qlementine the drawing code reads theme dimension fields directly, so scaling must happen at the theme level.  So this PR adds:

- `Theme::scaled(double factor)` - returns a copy with all dimension fields (spacing, radii, control heights, icon sizes, font sizes, etc.) multiplied by `factor`. Fonts are regenerated via `initializeFonts()`.
- `QlementineStyle::setScaleFactor(double)` / `scaleFactor()` - stores an unscaled base theme internally; when the scale factor changes, recomputes the active theme from `baseTheme.scaled(factor)` and triggers a full repaint. The factor is clamped to `[0.5, 4.0]`.

The goal is to make this completely opt-in and invisible to anyone not using the feature: scale factor defaults to `1.0`, and `scaled(1.0)` returns an early `*this` copy. `setTheme()` path is one extra `Theme` copy for the base. It always scales from the original base theme, never from an already-scaled theme (no drift).  No changes to drawing/layout code.

Happy to adjust the approach - mainly wanted to start a conversation about whether this is something you'd accept.  

This is an example of the behavior I have in my previous solution and what I'd like to achieve with Qlementine:

https://github.com/user-attachments/assets/dd790f59-4c5a-4b14-af55-a34ac8048628

**note**:  I haven't yet tested this in a real app