### PR TITLE
Add `TextHideMnemonic` flag to `drawComplexControl` for `CC_GroupBox`

### DIFF
--- a/lib/src/style/QlementineStyle.cpp
+++ b/lib/src/style/QlementineStyle.cpp
@@ -3121,7 +3121,7 @@ void QlementineStyle::drawComplexControl(
             fm.elidedText(groupBoxOpt->text, Qt::ElideRight, textRect.width(), Qt::TextSingleLine);
           const auto mouse = getMouseState(groupBoxOpt->state);
           const auto& textColor = groupBoxTitleColor(mouse, w);
-          constexpr auto textFlags = Qt::AlignVCenter | Qt::AlignBaseline | Qt::TextSingleLine | Qt::AlignLeft;
+          constexpr auto textFlags = Qt::AlignVCenter | Qt::AlignBaseline | Qt::TextSingleLine | Qt::AlignLeft | Qt::TextHideMnemonic;
           p->setFont(font);
           p->setPen(textColor);
           p->setRenderHint(QPainter::Antialiasing, true);


### PR DESCRIPTION
When switching between qlementine and native styles, I noticed that the ampersand heuristic wasn't respected in qlementine: 

### qlementine

<img width="190" height="83" alt="Screenshot 2026-03-18 at 2 02 02 PM" src="https://github.com/user-attachments/assets/a9b79263-5fe5-4f16-ace2-8d8c7f416548" />

### native

<img width="172" height="68" alt="Screenshot 2026-03-18 at 2 02 48 PM" src="https://github.com/user-attachments/assets/18c908b0-4d65-47dd-9c53-0e6a790790a8" />


seems like a very localized oversight, just in the drawing of `SC_GroupBoxCheckBox`.  This PR fixes it