### PR TITLE
fix `ThemeManager` constructor and style getter

### DIFF
--- a/lib/src/style/ThemeManager.cpp
+++ b/lib/src/style/ThemeManager.cpp
@@ -12,13 +12,10 @@ ThemeManager::ThemeManager(QObject* parent)
 ThemeManager::ThemeManager(QlementineStyle* style, QObject* parent)
   : QObject(parent) {
   setStyle(style);
-  if (parent == nullptr) {
-    setParent(style);
-  }
 }
 
 QlementineStyle* ThemeManager::style() const {
-  return nullptr;
+  return _style;
 }
 
 void ThemeManager::setStyle(QlementineStyle* style) {


### PR DESCRIPTION
- In `ThemeManager.cpp`, `style()` returns `nullptr` instead of `_style`. Internal methods use `_style` directly
so this doesn't affect C++ behavior, but the public API is broken.

- The constructor calls `setParent(style)` when no parent is given. This reparents the object on the C++ side
without notifying the binding layer (see https://github.com/pyapp-kit/PyQlementine), causing ownership conflicts that invalidate the internal `QPointer<QlementineStyle>`. `setCurrentTheme()` / `setCurrentThemeIndex()` then silently do
nothing.