### PR TITLE
include QCoreApplication in MenuEventFilter.hpp

### DIFF
--- a/lib/src/style/eventFilters/MenuEventFilter.hpp
+++ b/lib/src/style/eventFilters/MenuEventFilter.hpp
@@ -6,6 +6,7 @@
 #include <oclero/qlementine/style/QlementineStyle.hpp>
 #include <oclero/qlementine/utils/MenuUtils.hpp>
 
+#include <QCoreApplication>
 #include <QEvent>
 #include <QObject>
 #include <QMenu>


### PR DESCRIPTION
`MenuEventFilter.hpp` uses `QCoreApplication::sendEvent()` without including `<QCoreApplication>`. It resolves transitively through `QlementineStyle.hpp` -> `QCommonStyle` -> Qt internals, but that's an implicit dependency. This adds the explicit include.