### PR TITLE
fix: adjust LineEdit width calculation to use content size

### DIFF
--- a/lib/src/style/QlementineStyle.cpp
+++ b/lib/src/style/QlementineStyle.cpp
@@ -3993,8 +3993,10 @@ QSize QlementineStyle::sizeFromContents(
       break;
     case CT_LineEdit:
       if (const auto* optFrame = qstyleoption_cast<const QStyleOptionFrame*>(opt)) {
-        const auto r = optFrame->rect;
-        const auto w = r.width() - 2 * hardcodedLineEditHMargin;
+        // Use contentSize (font-metrics-based) rather than optFrame->rect (current widget
+        // geometry) so that sizeHint/minimumSizeHint report a content-driven width instead
+        // of echoing back the widget's existing size.
+        const auto w = contentSize.width() - 2 * hardcodedLineEditHMargin;
         const auto h = _impl->theme.controlHeightLarge;
         const auto* parent = widget->parentWidget();
         const auto* treeView = parent ? qobject_cast<const QAbstractItemView*>(parent->parentWidget()) : nullptr;

--- a/lib/src/style/QlementineStyle.cpp
+++ b/lib/src/style/QlementineStyle.cpp
@@ -3992,7 +3992,7 @@ QSize QlementineStyle::sizeFromContents(
       //return opt->rect.size();
       break;
     case CT_LineEdit:
-      if (const auto* optFrame = qstyleoption_cast<const QStyleOptionFrame*>(opt)) {
+      if (qstyleoption_cast<const QStyleOptionFrame*>(opt)) {
         // Use contentSize (font-metrics-based) rather than optFrame->rect (current widget
         // geometry) so that sizeHint/minimumSizeHint report a content-driven width instead
         // of echoing back the widget's existing size.


### PR DESCRIPTION
While trying to apply Qlementine to an existing app with a number of complex widgets (though: widgets that don't themselves have any magic style overrides) I have been finding a number of cases where widgets were forcing a min-width much larger than usual/necessary.    (i.e. I can't "just" apply QlementineStyle() without things looking pretty bad)

This patch fixes it for me.  But, please let me know if it looks risky for any of the qlementine-specific widgets you have here.
