### PR TITLE
feat: Add `makeIconFromSvgData` overloads for creating icons from in-memory SVG data

### DIFF
--- a/lib/include/oclero/qlementine/style/QlementineStyle.hpp
+++ b/lib/include/oclero/qlementine/style/QlementineStyle.hpp
@@ -76,6 +76,9 @@ public:
   QIcon makeThemedIconFromName(
     const QString& name, const QSize& size = QSize(16, 16), ColorRole role = ColorRole::Secondary) const;
 
+  QIcon makeThemedIconFromData(
+    const QByteArray& svgData, const QSize& size = QSize(16, 16), ColorRole role = ColorRole::Secondary) const;
+
   // Allows to customize quickly the way QlementineStyle gets its icons. SVG paths preferred.
   void setIconPathGetter(const std::function<QString(QString)>& func);
 

--- a/lib/include/oclero/qlementine/utils/IconUtils.hpp
+++ b/lib/include/oclero/qlementine/utils/IconUtils.hpp
@@ -26,4 +26,11 @@ struct IconTheme {
 /// Makes an icon from the file located at the path in parameter and colorizes the QPixmaps. Fixes the standard Qt behavior.
 [[maybe_unused]] QIcon makeIconFromSvg(
   const QString& svgPath, const IconTheme& iconTheme, const QSize& size = QSize(16, 16));
+
+/// Makes an icon from SVG data in memory. Fixes the standard Qt behavior.
+[[maybe_unused]] QIcon makeIconFromSvgData(const QByteArray& svgData, const QSize& size);
+
+/// Makes an icon from SVG data in memory and colorizes the QPixmaps. Fixes the standard Qt behavior.
+[[maybe_unused]] QIcon makeIconFromSvgData(
+  const QByteArray& svgData, const IconTheme& iconTheme, const QSize& size = QSize(16, 16));
 } // namespace oclero::qlementine

--- a/lib/src/style/QlementineStyle.cpp
+++ b/lib/src/style/QlementineStyle.cpp
@@ -377,6 +377,11 @@ QIcon QlementineStyle::makeThemedIconFromName(const QString& name, const QSize& 
   }
 }
 
+QIcon QlementineStyle::makeThemedIconFromData(const QByteArray& svgData, const QSize& size, ColorRole role) const {
+  const auto iconTheme = _impl->iconThemeFromTheme(role);
+  return makeIconFromSvgData(svgData, iconTheme, size);
+}
+
 void QlementineStyle::setIconPathGetter(const std::function<QString(QString)>& func) {
   _impl->iconPathFunc = func;
 }

--- a/lib/src/utils/IconUtils.cpp
+++ b/lib/src/utils/IconUtils.cpp
@@ -92,4 +92,64 @@ QIcon makeIconFromSvg(const QString& svgPath, const IconTheme& iconTheme, const 
 
   return icon;
 }
+
+QIcon makeIconFromSvgData(const QByteArray& svgData, const QSize& size) {
+  if (svgData.isEmpty() || size.isEmpty())
+    return {};
+
+  QIcon icon;
+
+  QSvgRenderer svgRenderer(svgData);
+  svgRenderer.setAspectRatioMode(Qt::AspectRatioMode::KeepAspectRatio);
+
+  for (const auto pxRatio : { 1., 2. }) {
+    QPixmap pixmap(size * pxRatio);
+    pixmap.fill(Qt::transparent);
+    {
+      QPainter painter(&pixmap);
+      painter.setRenderHint(QPainter::Antialiasing, true);
+      svgRenderer.render(&painter, pixmap.rect());
+    }
+    pixmap.setDevicePixelRatio(pxRatio);
+
+    for (const auto iconMode : { QIcon::Normal, QIcon::Disabled, QIcon::Active, QIcon::Selected }) {
+      for (const auto iconState : { QIcon::On, QIcon::Off }) {
+        icon.addPixmap(pixmap, iconMode, iconState);
+      }
+    }
+  }
+
+  return icon;
+}
+
+QIcon makeIconFromSvgData(const QByteArray& svgData, const IconTheme& iconTheme, const QSize& size) {
+  if (svgData.isEmpty() || size.isEmpty())
+    return {};
+
+  QIcon icon;
+
+  QSvgRenderer svgRenderer(svgData);
+  svgRenderer.setAspectRatioMode(Qt::AspectRatioMode::KeepAspectRatio);
+
+  for (const auto pxRatio : { 1, 2 }) {
+    QPixmap pixmap(size * pxRatio);
+    pixmap.fill(Qt::transparent);
+    {
+      QPainter painter(&pixmap);
+      painter.setRenderHint(QPainter::Antialiasing, true);
+      svgRenderer.render(&painter, pixmap.rect());
+    }
+    pixmap.setDevicePixelRatio(static_cast<double>(pxRatio));
+
+    for (const auto iconMode : { QIcon::Normal, QIcon::Disabled, QIcon::Active, QIcon::Selected }) {
+      for (const auto iconState : { QIcon::On, QIcon::Off }) {
+        const auto& fgColor = iconTheme.color(iconMode, iconState);
+        const auto coloredPixmap = qlementine::getColorizedPixmap(pixmap, fgColor);
+        icon.addPixmap(coloredPixmap, iconMode, iconState);
+      }
+    }
+  }
+
+  return icon;
+}
 } // namespace oclero::qlementine


### PR DESCRIPTION
Adds `makeIconFromSvgData(QByteArray, QSize)` and `makeIconFromSvgData(QByteArray, IconTheme, QSize)` free functions, mirroring the existing `makeIconFromSvg` file-path-based API. Also adds `QlementineStyle::makeThemedIconFromData` for convenience, following the same pattern as `makeThemedIcon`.

This is useful when SVG data is embedded or generated at runtime rather than loaded from a file on disk... which, though it may not be all that common in a C++ context, is very common in python, and this change would facilitate a lot of very nice dynamic python-side features.

note: I intentionally followed existing patterns (which inline similar functionality in a couple different functions) for consistency, but there is an opportunity to reduce code with a common function:

```cpp
QIcon renderSvgToIcon(
    QSvgRenderer& svgRenderer, const QSize& size, const IconTheme* iconTheme = nullptr
) {  }
```

and then all the `makeIcon()` functions would use it:

```cpp
renderSvgToIcon(svgRenderer, ...
```

so, if you're open to accepting this PR, but want to reduce code, let me know and I can make that change