### PR TITLE
refactor: rename drawRoundedRectF to drawRoundedRect for consistency

### DIFF
--- a/lib/src/utils/PrimitiveUtils.cpp
+++ b/lib/src/utils/PrimitiveUtils.cpp
@@ -191,7 +191,7 @@ void drawRoundedRect(QPainter* p, QRectF const& rect, QBrush const& brush, qreal
   }
 }
 
-void drawRoundedRectF(QPainter* p, QRectF const& rect, QBrush const& brush, RadiusesF const& radiuses) {
+void drawRoundedRect(QPainter* p, QRectF const& rect, QBrush const& brush, RadiusesF const& radiuses) {
   if (radiuses.hasSameRadius()) {
     drawRoundedRect(p, rect, brush, radiuses.topLeft);
   } else {


### PR DESCRIPTION
Very minor fix, discovered while working on bindings:

`drawRoundedRect(QPainter*, QRectF, QBrush, RadiusesF)` is declared in the header but the source defines it as `drawRoundedRectF`, making the overload unusable outside the translation unit.  (not that it's actually used internally anywhere)