### PR TITLE
refactor: Use Q_SIGNALS sections instead of Q_SIGNAL prefix for signal declarations

### DIFF
--- a/lib/include/oclero/qlementine/style/QlementineStyle.hpp
+++ b/lib/include/oclero/qlementine/style/QlementineStyle.hpp
@@ -53,12 +53,14 @@ public:
   Theme const& theme() const;
   void setTheme(Theme const& theme);
   void setThemeJsonPath(QString const& jsonPath);
-  Q_SIGNAL void themeChanged();
-
   bool animationsEnabled() const;
   void setAnimationsEnabled(bool enabled);
-  Q_SIGNAL void animationsEnabledChanged();
 
+Q_SIGNALS:
+  void themeChanged();
+  void animationsEnabledChanged();
+
+public:
   virtual void triggerCompleteRepaint();
 
   void setAutoIconColor(AutoIconColor autoIconColor);

--- a/lib/include/oclero/qlementine/style/ThemeManager.hpp
+++ b/lib/include/oclero/qlementine/style/ThemeManager.hpp
@@ -33,10 +33,8 @@ public:
 
   QString currentTheme() const;
   void setCurrentTheme(const QString& key);
-  Q_SIGNAL void currentThemeChanged();
 
   int themeCount() const;
-  Q_SIGNAL void themeCountChanged();
 
   Q_SLOT void setNextTheme();
   Q_SLOT void setPreviousTheme();
@@ -45,6 +43,10 @@ public:
 
   int currentThemeIndex() const;
   void setCurrentThemeIndex(int index);
+
+Q_SIGNALS:
+  void currentThemeChanged();
+  void themeCountChanged();
 
 private:
   void synchronizeThemeOnStyle();

--- a/lib/include/oclero/qlementine/widgets/AbstractItemListWidget.hpp
+++ b/lib/include/oclero/qlementine/widgets/AbstractItemListWidget.hpp
@@ -34,23 +34,18 @@ public:
   QSize sizeHint() const override;
 
   int itemCount() const;
-  Q_SIGNAL void itemCountChanged();
 
   int currentIndex() const;
   void setCurrentIndex(int index);
-  Q_SIGNAL void currentIndexChanged();
 
   QVariant currentData() const;
   void setCurrentData(const QVariant& currentData);
-  Q_SIGNAL void currentDataChanged();
 
   const QSize& iconSize() const;
   void setIconSize(const QSize& size);
-  Q_SIGNAL void iconSizeChanged();
 
   bool itemsShouldExpand() const;
   void setItemsShouldExpand(bool expand);
-  Q_SIGNAL void itemsShouldExpandChanged();
 
   int addItem(const QString& text, const QIcon& icon = {}, const QString& badge = {}, const QVariant& itemData = {});
   void removeItem(int index);
@@ -75,6 +70,13 @@ public:
   Q_SLOT void moveToPreviousItem();
 
   virtual void initStyleOptionFocus(QStyleOptionFocusRoundedRect& opt) const;
+
+Q_SIGNALS:
+  void itemCountChanged();
+  void currentIndexChanged();
+  void currentDataChanged();
+  void iconSizeChanged();
+  void itemsShouldExpandChanged();
 
 protected: // QWidget override.
   void keyPressEvent(QKeyEvent* e) override;

--- a/lib/include/oclero/qlementine/widgets/Expander.hpp
+++ b/lib/include/oclero/qlementine/widgets/Expander.hpp
@@ -21,23 +21,24 @@ public:
 
   bool expanded() const;
   Q_SLOT void setExpanded(bool expanded);
-  Q_SIGNAL void expandedChanged();
   void toggleExpanded();
-
-  Q_SIGNAL void aboutToExpand();
-  Q_SIGNAL void aboutToShrink();
-  Q_SIGNAL void didExpand();
-  Q_SIGNAL void didShrink();
 
   Qt::Orientation orientation() const;
   Q_SLOT void setOrientation(Qt::Orientation orientation);
-  Q_SIGNAL void orientationChanged();
 
   QWidget* content() const;
   void setContent(QWidget* content);
-  Q_SIGNAL void contentChanged();
 
   QSize sizeHint() const override;
+
+Q_SIGNALS:
+  void expandedChanged();
+  void aboutToExpand();
+  void aboutToShrink();
+  void didExpand();
+  void didShrink();
+  void orientationChanged();
+  void contentChanged();
 
 protected:
   bool event(QEvent* e) override;

--- a/lib/include/oclero/qlementine/widgets/IconWidget.hpp
+++ b/lib/include/oclero/qlementine/widgets/IconWidget.hpp
@@ -21,13 +21,15 @@ public:
 
   const QIcon& icon() const;
   Q_SLOT void setIcon(const QIcon& icon);
-  Q_SIGNAL void iconChanged();
 
   const QSize& iconSize() const;
   Q_SLOT void setIconSize(const QSize& iconSize);
-  Q_SIGNAL void iconSizeChanged();
 
   QSize sizeHint() const override;
+
+Q_SIGNALS:
+  void iconChanged();
+  void iconSizeChanged();
 
 protected:
   void paintEvent(QPaintEvent* e) override;

--- a/lib/include/oclero/qlementine/widgets/Label.hpp
+++ b/lib/include/oclero/qlementine/widgets/Label.hpp
@@ -23,7 +23,9 @@ public:
 
   TextRole role() const;
   Q_SLOT void setRole(TextRole role);
-  Q_SIGNAL void roleChanged();
+
+Q_SIGNALS:
+  void roleChanged();
 
 protected:
   bool event(QEvent* e) override;

--- a/lib/include/oclero/qlementine/widgets/LineEdit.hpp
+++ b/lib/include/oclero/qlementine/widgets/LineEdit.hpp
@@ -23,14 +23,16 @@ public:
 
   const QIcon& icon() const;
   Q_SLOT void setIcon(const QIcon& icon);
-  Q_SIGNAL void iconChanged();
 
   void setUseMonoSpaceFont(bool useMonoSpaceFont);
   bool useMonoSpaceFont() const;
 
   Status status() const;
   Q_SLOT void setStatus(Status status);
-  Q_SIGNAL void statusChanged();
+
+Q_SIGNALS:
+  void iconChanged();
+  void statusChanged();
 
 protected:
   void paintEvent(QPaintEvent* evt) override;

--- a/lib/include/oclero/qlementine/widgets/LoadingSpinner.hpp
+++ b/lib/include/oclero/qlementine/widgets/LoadingSpinner.hpp
@@ -22,10 +22,12 @@ public:
 
   bool spinning() const;
   Q_SLOT void setSpinning(bool);
-  Q_SIGNAL void spinningChanged();
 
   QSize minimumSizeHint() const override;
   QSize sizeHint() const override;
+
+Q_SIGNALS:
+  void spinningChanged();
 
 protected:
   void paintEvent(QPaintEvent* evt) override;

--- a/lib/include/oclero/qlementine/widgets/NotificationBadge.hpp
+++ b/lib/include/oclero/qlementine/widgets/NotificationBadge.hpp
@@ -29,27 +29,29 @@ public:
 
   const QString& text() const;
   Q_SLOT void setText(const QString&);
-  Q_SIGNAL void textChanged();
 
   const QColor& foregroundColor() const;
   Q_SLOT void setForegroundColor(const QColor&);
-  Q_SIGNAL void foregroundColorChanged();
 
   const QColor& backgroundColor() const;
   Q_SLOT void setBackgroundColor(const QColor&);
-  Q_SIGNAL void backgroundColorChanged();
 
   const QPoint& relativePosition() const;
   Q_SLOT void setRelativePosition(const QPoint&);
   void setRelativePosition(int x, int y);
-  Q_SIGNAL void relativePositionChanged();
 
   const QMargins& padding() const;
   Q_SLOT void setPadding(const QMargins&);
-  Q_SIGNAL void paddingChanged();
 
   QSize minimumSizeHint() const override;
   QSize sizeHint() const override;
+
+Q_SIGNALS:
+  void textChanged();
+  void foregroundColorChanged();
+  void backgroundColorChanged();
+  void relativePositionChanged();
+  void paddingChanged();
 
 protected:
   void paintEvent(QPaintEvent* evt) override;

--- a/lib/include/oclero/qlementine/widgets/PlainTextEdit.hpp
+++ b/lib/include/oclero/qlementine/widgets/PlainTextEdit.hpp
@@ -25,7 +25,9 @@ public:
 
   Status status() const;
   Q_SLOT void setStatus(Status status);
-  Q_SIGNAL void statusChanged();
+
+Q_SIGNALS:
+  void statusChanged();
 
 private:
   void updateFont();

--- a/lib/include/oclero/qlementine/widgets/RoundedFocusFrame.hpp
+++ b/lib/include/oclero/qlementine/widgets/RoundedFocusFrame.hpp
@@ -19,7 +19,9 @@ public:
 
   const RadiusesF& radiuses() const;
   Q_SLOT void setRadiuses(const RadiusesF&);
-  Q_SIGNAL void radiusesChanged();
+
+Q_SIGNALS:
+  void radiusesChanged();
 
 private:
   RadiusesF _radiuses;

--- a/lib/include/oclero/qlementine/widgets/StatusBadgeWidget.hpp
+++ b/lib/include/oclero/qlementine/widgets/StatusBadgeWidget.hpp
@@ -19,13 +19,15 @@ public:
 
   StatusBadge badge() const;
   Q_SLOT void setBadge(StatusBadge badge);
-  Q_SIGNAL void badgeChanged();
 
   StatusBadgeSize badgeSize() const;
   Q_SLOT void setBadgeSize(StatusBadgeSize size);
-  Q_SIGNAL void badgeSizeChanged();
 
   QSize sizeHint() const override;
+
+Q_SIGNALS:
+  void badgeChanged();
+  void badgeSizeChanged();
 
 protected:
   void paintEvent(QPaintEvent* e) override;


### PR DESCRIPTION
@oclero let me how you feel about this one:

This is a pure style change: both forms produce identical MOC output. The motivation is that shiboken6 (PySide6's binding generator) only recognizes signals declared in `Q_SIGNALS:` sections, not the `Q_SIGNAL` prefix form, due to a limitation in its clang-based header parser.  (it's arguably a bug in shiboken, but it's been there for years).

I spent quite a while trying workarounds, but this is basically the only thing I came up with that would let the signals be wrapped correctly in PySide6.  It looks like you do already use this form in a number of places, so hopefully it's not an issue to standardize them all?

If not, then the other solution would be for me to maintain a patch file in PyQlementine that gets replaced on top of the submodule before building.