### PR TITLE
fix: emit more missing signals

### DIFF
--- a/lib/src/widgets/AbstractItemListWidget.cpp
+++ b/lib/src/widgets/AbstractItemListWidget.cpp
@@ -50,12 +50,16 @@ int AbstractItemListWidget::currentIndex() const {
 void AbstractItemListWidget::setCurrentIndex(int index) {
   index = index < 0 || index > itemCount() - 1 ? -1 : index;
   if (index != _currentIndex) {
+    const auto oldData = currentData();
     _currentIndex = index;
     _focusedIndex = index;
     update();
     updateCurrentIndexAnimation();
     updateItemsAnimations();
     Q_EMIT currentIndexChanged();
+    if (currentData() != oldData) {
+      Q_EMIT currentDataChanged();
+    }
   }
 }
 

--- a/lib/src/widgets/IconWidget.cpp
+++ b/lib/src/widgets/IconWidget.cpp
@@ -42,6 +42,7 @@ const QIcon& IconWidget::icon() const {
 
 void IconWidget::setIcon(const QIcon& icon) {
   _icon = icon;
+  Q_EMIT iconChanged();
   update();
 }
 

--- a/lib/src/widgets/LineEdit.cpp
+++ b/lib/src/widgets/LineEdit.cpp
@@ -22,6 +22,7 @@ const QIcon& LineEdit::icon() const {
 
 void LineEdit::setIcon(const QIcon& icon) {
   _icon = icon;
+  Q_EMIT iconChanged();
   update();
   if (_icon.isNull()) {
     setTextMargins(0, 0, 0, 0);

--- a/lib/src/widgets/NotificationBadge.cpp
+++ b/lib/src/widgets/NotificationBadge.cpp
@@ -114,7 +114,7 @@ const QColor& NotificationBadge::backgroundColor() const {
 void NotificationBadge::setBackgroundColor(const QColor& color) {
   if (color != _backgroundColor) {
     _backgroundColor = color;
-    Q_EMIT foregroundColorChanged();
+    Q_EMIT backgroundColorChanged();
     update();
   }
 }


### PR DESCRIPTION
Fixes more missing signals (apologies, I should have looked for these when I did https://github.com/oclero/qlementine/pull/157 ... but this time I think we've got them all)

The one I am least certain about is emitting `currentDataChanged` from `AbstractItemListWidget::setCurrentIndex`.   That `currentData` seems to be derived from `currentIndex`, and changes with `setCurrentIndex` ... but there was no `currentDataChanged` emitter.