### PR TITLE
fix: improve text width calculation for buttons

### DIFF
--- a/lib/src/style/QlementineStyle.cpp
+++ b/lib/src/style/QlementineStyle.cpp
@@ -2379,23 +2379,9 @@ QRect QlementineStyle::subElementRect(SubElement se, const QStyleOption* opt, co
         const auto hasText = !optButton->text.isEmpty();
         const auto hasMenu = optButton->features.testFlag(QStyleOptionButton::HasMenu);
         const auto padding = pixelMetric(PM_ButtonMargin);
-        auto [paddingLeft, paddingRight] = getHPaddings(hasIcon, hasText, hasMenu, padding);
-        const auto totalPadding = paddingLeft + paddingRight;
-        if (totalPadding >= opt->rect.width()) {
+        const auto [paddingLeft, paddingRight] = getHPaddings(hasIcon, hasText, hasMenu, padding);
+        if (paddingLeft + paddingRight >= opt->rect.width()) {
           return opt->rect;
-        }
-        // When the button is squeezed below its ideal size, reduce padding
-        // proportionally by the deficit so content space is preserved first.
-        // (Ultimately, this is user error, but showing text is better than showing nothing)
-        if (hasText && totalPadding > 0) {
-          const auto textW = qlementine::textWidth(optButton->fontMetrics, optButton->text);
-          const auto idealWidth = textW + totalPadding;
-          if (opt->rect.width() < idealWidth) {
-            const auto deficit = idealWidth - opt->rect.width();
-            const auto reduction = std::min(deficit, totalPadding);
-            paddingLeft -= paddingLeft * reduction / totalPadding;
-            paddingRight -= paddingRight * reduction / totalPadding;
-          }
         }
         return opt->rect.marginsRemoved({ paddingLeft, 0, paddingRight, 0 });
       }

--- a/lib/src/style/QlementineStyle.cpp
+++ b/lib/src/style/QlementineStyle.cpp
@@ -2379,9 +2379,23 @@ QRect QlementineStyle::subElementRect(SubElement se, const QStyleOption* opt, co
         const auto hasText = !optButton->text.isEmpty();
         const auto hasMenu = optButton->features.testFlag(QStyleOptionButton::HasMenu);
         const auto padding = pixelMetric(PM_ButtonMargin);
-        const auto [paddingLeft, paddingRight] = getHPaddings(hasIcon, hasText, hasMenu, padding);
-        if (paddingLeft + paddingRight >= opt->rect.width()) {
+        auto [paddingLeft, paddingRight] = getHPaddings(hasIcon, hasText, hasMenu, padding);
+        const auto totalPadding = paddingLeft + paddingRight;
+        if (totalPadding >= opt->rect.width()) {
           return opt->rect;
+        }
+        // When the button is squeezed below its ideal size, reduce padding
+        // proportionally by the deficit so content space is preserved first.
+        // (Ultimately, this is user error, but showing text is better than showing nothing)
+        if (hasText && totalPadding > 0) {
+          const auto textW = qlementine::textWidth(optButton->fontMetrics, optButton->text);
+          const auto idealWidth = textW + totalPadding;
+          if (opt->rect.width() < idealWidth) {
+            const auto deficit = idealWidth - opt->rect.width();
+            const auto reduction = std::min(deficit, totalPadding);
+            paddingLeft -= paddingLeft * reduction / totalPadding;
+            paddingRight -= paddingRight * reduction / totalPadding;
+          }
         }
         return opt->rect.marginsRemoved({ paddingLeft, 0, paddingRight, 0 });
       }

--- a/lib/src/style/QlementineStyle.cpp
+++ b/lib/src/style/QlementineStyle.cpp
@@ -1107,8 +1107,7 @@ void QlementineStyle::drawControl(ControlElement ce, const QStyleOption* opt, QP
         const auto& colorizedPixmap = getColorizedPixmap(pixmap, autoIconColor(w), currentFgColor, currentFgColor);
         const auto pixmapPixelRatio = colorizedPixmap.devicePixelRatio();
         const auto iconW = colorizedPixmap.isNull() ? 0 : static_cast<int>(colorizedPixmap.width() / pixmapPixelRatio);
-        const auto fmFlags = hasMenu ? Qt::AlignLeft : Qt::AlignCenter;
-        const auto textW = optButton->fontMetrics.boundingRect(optButton->rect, fmFlags, optButton->text).width();
+        const auto textW = qlementine::textWidth(optButton->fontMetrics, optButton->text);
         const auto iconSpacing = iconW > 0 && !optButton->text.isEmpty() && textW > 0 ? spacing : 0;
         const auto& fgRect =
           hasMenu ? optButton->rect.marginsRemoved(QMargins{ 0, 0, indicatorSize + spacing, 0 }) : optButton->rect;
@@ -1136,7 +1135,7 @@ void QlementineStyle::drawControl(ControlElement ce, const QStyleOption* opt, QP
         if (availableW > 0 && textW > 0) {
           const auto elidedText =
             optButton->fontMetrics.elidedText(optButton->text, Qt::ElideRight, availableW, Qt::TextSingleLine);
-          const auto elidedTextW = optButton->fontMetrics.boundingRect(optButton->rect, fmFlags, elidedText).width();
+          const auto elidedTextW = qlementine::textWidth(optButton->fontMetrics, elidedText);
           const auto textRect = QRect{ availableX, contentRect.y(), elidedTextW, contentRect.height() };
           int textFlags = Qt::AlignVCenter | Qt::AlignBaseline | Qt::TextSingleLine | Qt::TextHideMnemonic;
           if (iconW == 0) {
@@ -2381,6 +2380,9 @@ QRect QlementineStyle::subElementRect(SubElement se, const QStyleOption* opt, co
         const auto hasMenu = optButton->features.testFlag(QStyleOptionButton::HasMenu);
         const auto padding = pixelMetric(PM_ButtonMargin);
         const auto [paddingLeft, paddingRight] = getHPaddings(hasIcon, hasText, hasMenu, padding);
+        if (paddingLeft + paddingRight >= opt->rect.width()) {
+          return opt->rect;
+        }
         return opt->rect.marginsRemoved({ paddingLeft, 0, paddingRight, 0 });
       }
       return opt->rect;


### PR DESCRIPTION
Hi @oclero 

I found, when using qlementine, that a few "manually sized" buttons were not showing text.  Specifically, if the button ever ends up smaller than its `sizeHint`, then the style's drawing code measures text width incorrectly.

For example:

```
btn = QPushButton("1")
btn.setFixedSize(QSize(20, 20))
btn.show()
```

was not showing the text at all.  This fixes it, but please make sure it won't have a side effect of breaking any styles for you that I haven't anticipated.