### PR TITLE
fix: Fix ComboboxItemViewFilter popup height calculation to consider available space in both directions

### DIFF
--- a/lib/src/style/eventFilters/ComboboxItemViewFilter.hpp
+++ b/lib/src/style/eventFilters/ComboboxItemViewFilter.hpp
@@ -102,10 +102,18 @@ private:
           // Height.
           const auto absoluteMinHeight = qlementineStyle->theme().controlHeightLarge * (isTreeView ? 5 : 1);
           const auto screen = view->screen();
-          const auto viewGlobalY = view->mapToGlobal(QPoint(0, 0)).y();  // Don't exceed the screen height when expanding a tree view.
-          const auto absoluteMaxHeight = screen != nullptr ?
-                                             screen->geometry().height() - 128 - viewGlobalY :
-                                             qlementineStyle->theme().controlHeightLarge * 10;
+          // Don't exceed the available screen space above or below the combobox.
+          const auto comboGlobalY = _comboBox->mapToGlobal(QPoint(0, 0)).y();
+          const auto screenPadding = 128;
+          int absoluteMaxHeight;
+          if (screen != nullptr) {
+            const auto screenGeom = screen->availableGeometry();
+            const auto spaceBelow = screenGeom.bottom() - comboGlobalY - _comboBox->height() - screenPadding;
+            const auto spaceAbove = comboGlobalY - screenGeom.top() - screenPadding;
+            absoluteMaxHeight = std::max(spaceBelow, spaceAbove);
+          } else {
+            absoluteMaxHeight = qlementineStyle->theme().controlHeightLarge * 10;
+          }
           const auto height = std::min(absoluteMaxHeight, std::max(absoluteMinHeight, viewMinimumSizeHint().height()));
 
           view->setFixedWidth(width);


### PR DESCRIPTION
The previous code only measured space below the view's global Y position, causing unnecessarily small popups (with scroll arrows) when the combobox is near the bottom of the screen and the popup is displayed above.