### PR TITLE
fix: update item rects when adding items to AbstractItemListWidget

### DIFF
--- a/lib/src/widgets/AbstractItemListWidget.cpp
+++ b/lib/src/widgets/AbstractItemListWidget.cpp
@@ -126,6 +126,7 @@ int AbstractItemListWidget::addItem(
 
   update();
   updateGeometry();
+  updateItemRects();
   updateItemsAnimations();
   updateCurrentIndexAnimation();
   Q_EMIT itemCountChanged();


### PR DESCRIPTION
- update item rects immediately after inserting a new item into `AbstractItemListWidget`