### PR TITLE
fix: assign custom type to QStyleOptionFocusRoundedRect

### DIFF
--- a/lib/include/oclero/qlementine/style/QlementineStyleOption.hpp
+++ b/lib/include/oclero/qlementine/style/QlementineStyleOption.hpp
@@ -11,16 +11,21 @@ namespace oclero::qlementine {
 /// Allows to customize the radius of the focus border.
 class QStyleOptionFocusRoundedRect : public QStyleOptionFocusRect {
 public:
+  enum StyleOptionType { Type = SO_CustomBase + 2 };
+
   RadiusesF radiuses;
   int hMargin{ 0 };
   int vMargin{ 0 };
   QColor borderColor;
 
-  QStyleOptionFocusRoundedRect() = default;
+  QStyleOptionFocusRoundedRect() {
+    type = Type;
+  }
 
   static QStyleOptionFocusRoundedRect fromBase(QStyleOption const& opt, QRect const& rect, RadiusesF const& radiuses) {
     QStyleOptionFocusRoundedRect newOpt;
     newOpt.QStyleOption::operator=(opt);
+    newOpt.type = Type;
     newOpt.radiuses = radiuses;
     newOpt.rect = rect;
     return newOpt;

--- a/lib/src/style/QlementineStyle.cpp
+++ b/lib/src/style/QlementineStyle.cpp
@@ -1960,6 +1960,7 @@ void QlementineStyle::drawControl(ControlElement ce, const QStyleOption* opt, QP
 
         QStyleOptionFocusRoundedRect optFocus;
         optFocus.QStyleOption::operator=(*opt);
+        optFocus.type = QStyleOptionFocusRoundedRect::Type;
         optFocus.state.setFlag(State_HasFocus, hasFocus);
 
         // The focus frame is placed differently according to the widget.


### PR DESCRIPTION
## Summary
- Assign a custom `QStyleOption::type` ID to `QStyleOptionFocusRoundedRect` so `qstyleoption_cast` can distinguish it from `QStyleOptionFocusRect`

## Problem

`QStyleOptionFocusRoundedRect` inherits from `QStyleOptionFocusRect` without overriding the `type` field. Both classes share the same type ID (`SO_Default + 1`), so `qstyleoption_cast<const QStyleOptionFocusRoundedRect*>(opt)` incorrectly matches plain `QStyleOptionFocusRect` instances.

When `QColorDialog::QWellArray::paintCell` passes a `QStyleOptionFocusRect` to `drawPrimitive(PE_FrameFocusRect)`, the cast succeeds and `radiuses` is accessed on a `QStyleOptionFocusRect` that was never initialized for rounded rects → crash.

## Fix

Follow the same pattern already used by `QStyleOptionRoundedButton` in this codebase:
- Define `enum StyleOptionType { Type = SO_CustomBase + 2 }` (next available after `QStyleOptionRoundedButton`'s `SO_CustomBase + 1`)
- Set `type = Type` in the default constructor, copy constructor, and `fromBase()`
- Restore `type = Type` after `QStyleOption::operator=()` in `CE_FocusFrame` case

## Test Plan
- [x] `qstyleoption_cast<const QStyleOptionFocusRoundedRect*>()` now returns nullptr for plain `QStyleOptionFocusRect` — QColorDialog crash eliminated
- [x] All internal `QStyleOptionFocusRoundedRect` constructions properly set the custom type
- [x] Pattern matches existing `QStyleOptionRoundedButton` convention in this codebase

Fixes #144
