### PR TITLE
feat: also provide a Qt QStyle plugin

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,11 +12,11 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
       - name: Check Out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ public/
 # CMake files.
 CMakeUserPresets.json
 CMakeLists.txt.user
+
+# Clangd cache
+.cache/

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -198,3 +198,41 @@ install(FILES
 export(EXPORT "${PROJECT_NAME}Targets"
   FILE "${CMAKE_BINARY_DIR}/cmake/${PROJECT_NAME}Targets.cmake"
   NAMESPACE ${PROJECT_NAME}::)
+
+# Qt Style Plugin
+qt_add_plugin(qlementinestyleplugin
+  SHARED
+  CLASS_NAME QlementineStylePlugin
+  OUTPUT_NAME qlementine
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/style/QlementineStylePlugin.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/style/QlementineStylePlugin.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/style/qlementine_style_plugin.json
+  ${RESOURCES}
+)
+
+target_include_directories(qlementinestyleplugin
+  PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+)
+
+target_link_libraries(qlementinestyleplugin
+  PRIVATE
+    ${PROJECT_NAME}
+    Qt::Core
+    Qt::Widgets
+    Qt::Svg
+)
+
+set_target_properties(qlementinestyleplugin
+  PROPERTIES
+    FOLDER lib
+    CMAKE_AUTORCC ON
+    CMAKE_AUTOMOC ON
+    CMAKE_AUTOUIC ON
+)
+
+install(TARGETS qlementinestyleplugin
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}/qt6/plugins/styles"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_LIBDIR}/qt6/plugins/styles"
+)

--- a/lib/src/style/QlementineStylePlugin.cpp
+++ b/lib/src/style/QlementineStylePlugin.cpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: MIT
+
+#include "QlementineStylePlugin.hpp"
+#include "oclero/qlementine/style/QlementineStyle.hpp"
+
+namespace oclero::qlementine {
+
+QStyle* QlementineStylePlugin::create(const QString& key) {
+  if (key.toLower() == QStringLiteral("qlementine")) {
+    return new QlementineStyle();
+  }
+  return nullptr;
+}
+
+} // namespace oclero::qlementine

--- a/lib/src/style/QlementineStylePlugin.hpp
+++ b/lib/src/style/QlementineStylePlugin.hpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <QStylePlugin>
+
+namespace oclero::qlementine {
+
+class QlementineStylePlugin : public QStylePlugin {
+  Q_OBJECT
+  Q_PLUGIN_METADATA(IID "org.qt-project.Qt.QStyleFactoryInterface" FILE "qlementine_style_plugin.json")
+
+public:
+  QStyle* create(const QString& key) override;
+};
+
+} // namespace oclero::qlementine

--- a/lib/src/style/qlementine_style_plugin.json
+++ b/lib/src/style/qlementine_style_plugin.json
@@ -1,0 +1,3 @@
+{
+  "Keys": [ "qlementine" ]
+}


### PR DESCRIPTION
This could allows regular Qt widgets-based application override its style using the `-style` argument to use qlemontine as its style. If such Qt application has built-in feature to switch between Qt QStyle plugin-based theme switcher, which most KDE's applications do have, and some other Qt application have. Then qlemontine will become one available option automatically.

To test this feature, build the project, get the generated plugin file (.dll or .so file depends on the platform you use) and put it into the location that search for Qt plugins, and use `-style qlementine` argument (or use `QT_STYLE_OVERRIDE=qlementine` environment variable) to set the style.

Somewhat related:

- https://github.com/oclero/qlementine/issues/106#issuecomment-3268401846